### PR TITLE
chore: fix wrong description in issue template "hizollo"

### DIFF
--- a/.github/ISSUE_TEMPLATE/hizollo.yml
+++ b/.github/ISSUE_TEMPLATE/hizollo.yml
@@ -1,6 +1,6 @@
 name: HiZollo 的錯誤
 title: "[Bug]："
-description: 任何其它的問題可以在這裡提出
+description: 有關 HiZollo 機器人的錯誤，可以在這裡提出
 labels: ["bug", "hizollo"]
 body:
   - type: markdown


### PR DESCRIPTION
## 說明
就因為 copycat 太快了所以 hizollo template 的 description 是錯的。

因為不是什麼 fatal 或太嚴重的問題所以選擇併入 `dev` 分支，待下次版本發佈時改正就好了。