### PR TITLE
功能：預設關閉 Youtube 音樂系統

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ ID: 1022496087895973898
 Token: DYewdMZ138jskaXgFalU_JJ_wKBTjaC6kdgYnF2lyqnkb-HrU2y0JdY2xdpr7Do-P6zl
 ```
 
+### Youtube 音樂功能
+因應 Youtube 的聲明，Discord 會將被發現在播放 Youtube 音樂的機器人取消驗證。
+
+為了避免遭受處分，我們在程式中將播放 Youtube 音樂的功能上了鎖。如果你希望在你的複製品中可以啟用此功能，可以在你的 `.env` 檔案中加上一行
+```
+ENABLE_YT=1
+```
+，或是把 `/src/commands/Music/Play` 中 `<Lock></Lock>` 的部分刪掉。
+
+由於在未來我們可能會對音樂系統做改寫，啟用此功能的方法亦可能改變，對於使用此功能的人，請關注本章節和更新日誌。
+
 ## 官方伺服器
 如果有碰到任何使用上的問題，你都可以到我們的[官方伺服器](https://hizollo.ddns.net/server)中詢問。
 

--- a/src/commands/Music/Play.ts
+++ b/src/commands/Music/Play.ts
@@ -21,7 +21,8 @@
 import { Command } from "../../classes/Command";
 import { Source } from "../../classes/Source";
 import { ArgumentParseType, CommandType } from "../../utils/enums";
-import { ApplicationCommandOptionType, PermissionFlagsBits } from "discord.js";
+import { ApplicationCommandOptionType, PermissionFlagsBits, EmbedBuilder } from "discord.js";
+import Constant from '../../constant.json';
 
 export default class MusicPlay extends Command<[string]> {
   constructor() {
@@ -47,6 +48,26 @@ export default class MusicPlay extends Command<[string]> {
   }
 
   public async execute(source: Source, [keywordOrUrl]: [string]): Promise<void> {
+    //// <Lock>
+    if (!process.env.ENABLE_YT) {
+      const embed = new EmbedBuilder()
+        .applyHiZolloSettings(source.member, 'HiZollo 的幫助中心')
+        .setDescription(
+`
+由於 Google 和 Discord 的規範越來越嚴格，為了保證能繼續為各位提供服務，我們將暫時關閉音樂功能。
+
+我們會在設計好一個能夠運作的新的音樂功能後重新對外開放，請各位多注意我們的公告（</annoucement:894066153654198372>）。
+
+在這之前，你可以考慮使用 </youtube:894066844405739520> 指令來在語音頻道中播放來自 Youtube 的音樂。
+
+如果有任何問題或意見，你可以查看我們的[最近公告](${Constant.websiteLinks.annoucement})或加入 [HiZollo 官方伺服器](${Constant.mainGuild.inviteLink})。
+`);
+      await source.defer();
+      await source.update({ embeds: [embed] });
+      return;
+    }
+    //// </Lock>
+
     if (!source.client.music.has(source.guild.id)) {
       const command = source.client.commands.search(['music', 'join']) as Command;
       await command.execute(source, [true]);

--- a/src/commands/Music/Play.ts
+++ b/src/commands/Music/Play.ts
@@ -49,7 +49,7 @@ export default class MusicPlay extends Command<[string]> {
 
   public async execute(source: Source, [keywordOrUrl]: [string]): Promise<void> {
     //// <Lock>
-    if (!process.env.ENABLE_YT) {
+    if (process.env.ENABLE_YT === '1') {
       const embed = new EmbedBuilder()
         .applyHiZolloSettings(source.member, 'HiZollo 的幫助中心')
         .setDescription(

--- a/src/constant.json
+++ b/src/constant.json
@@ -18,6 +18,7 @@
     "changelog": "https://hizollo.ddns.net/changelog", 
     "commands": "https://hizollo.ddns.net/commands", 
     "tos": "https://hizollo.ddns.net/tos", 
+    "annoucement": "https://hizollo.ddns.net/annoucements", 
     "github": "https://github.com/HiZollo", 
     "source": "https://github.com/HiZollo/Junior-HiZollo", 
     "topgg": "https://top.gg/bot/584677291318312963", 


### PR DESCRIPTION
## 說明
因應最近的一些事，將 Youtube 音樂系統改為預設關閉。

## Blueprint
目前對音樂系統的規劃是會引入播放其它的音樂平臺的音樂（i.e. SoundCloud）。

Youtube 的部分，不會將其從 codebase 中移除，會和其它音樂平臺的系統並存，但預設關閉。使用這份專案的人可以自行用 README 中提供的方法解封，後果自行負責。

## 更改說明
- 因為現在只有一種音樂平臺所以 `play` 選擇直接 return。