### PR TITLE
feature: open access to all discord activities

### DIFF
--- a/src/commands/Activity.ts
+++ b/src/commands/Activity.ts
@@ -19,25 +19,33 @@
  */
 
 import { ButtonBuilder } from "@discordjs/builders";
-import { ActionRowBuilder, ButtonStyle, ChannelType, EmbedBuilder, InviteTargetType, PermissionFlagsBits } from "discord.js";
+import { ActionRowBuilder, ApplicationCommandOptionType, ButtonStyle, ChannelType, EmbedBuilder, InviteTargetType, PermissionFlagsBits } from "discord.js";
 import { Command } from "../classes/Command";
 import { Source } from "../classes/Source";
 import { CommandType } from "../utils/enums";
 
-export default class Youtube extends Command<[]> {
+export default class Youtube extends Command<[keyof typeof appIds]> {
   constructor() {
     super({ 
       type: CommandType.Fun, 
-      name: 'youtube', 
-      description: '建立一個邀請，讓你可以在 Discord 的語音頻道中與朋友一同觀看 Youtube 影片', 
-      aliases: ['yt'], 
+      name: 'activity', 
+      description: '讓你可以在 Discord 的語音頻道中與朋友同樂', 
+      extraDescription: '不填參數時我會建立可以讓你看 Youtube 的連結', 
+      aliases: ['youtube', 'yt'], 
+      options: [{
+        type: ApplicationCommandOptionType.String,
+        name: '活動',
+        description: '你要玩的活動',
+        required: false,
+        choices: Object.keys(appIds).map(id => ({ name: id, value: id }))
+      }],
       permissions: {
         bot: [PermissionFlagsBits.CreateInstantInvite]
       }
     });
   }
 
-  public async execute(source: Source): Promise<void> {
+  public async execute(source: Source, [appName]: [keyof typeof appIds]): Promise<void> {
     if (!(source.member && 'voice' in source.member && source.member.voice.channel)) {
       await source.defer({ ephemeral: true });
       await source.update('你必須在語音頻道內才能使用此指令');
@@ -50,10 +58,12 @@ export default class Youtube extends Command<[]> {
     }
     await source.defer();
 
+    if (!appName) appName = "WatchTogether";
+
     const invite = await source.member.voice.channel.createInvite({
       maxUses: 0,
       targetType: InviteTargetType.EmbeddedApplication,
-      targetApplication: this.appIds["WatchTogether"]
+      targetApplication: appIds[appName]
     });
 
     const inviteButton = new ButtonBuilder({
@@ -64,7 +74,7 @@ export default class Youtube extends Command<[]> {
 
     const helper = new EmbedBuilder()
       .applyHiZolloSettings(source.member, 'HiZollo 的幫助中心')
-      .setDescription('請點擊以下按鈕以開始在語音頻道中觀看 Youtube！');
+      .setDescription(`請點擊以下按鈕以開始在語音頻道中使用 ${appName}！`);
 
     await source.update({
       embeds: [helper],
@@ -73,27 +83,27 @@ export default class Youtube extends Command<[]> {
       })]
     });
   }
-
-  private appIds = Object.freeze({
-    "YouTubeTogether": "755600276941176913", 
-    "WatchTogether": "880218394199220334",  // 新的 YouTubeTogether
-    "PokerNight": "755827207812677713",
-    "Betrayal.io": "773336526917861400",
-    "Fishington.io": "814288819477020702",
-    "ChessInThePark": "832012774040141894",
-    "SketchyArtist": "879864070101172255",
-    "Awkword": "879863881349087252",
-    "DoodleCrew": "878067389634314250",
-    "SketchHeads": "902271654783242291",
-    "LetterLeague": "879863686565621790",
-    "WordSnacks": "879863976006127627",
-    "SpellCast": "852509694341283871",
-    "CheckersInThePark": "832013003968348200",
-    "Blazing8s": "832025144389533716",
-    "PuttParty": "945737671223947305",
-    "Land-io": "903769130790969345",
-    "BobbleLeague": "947957217959759964",
-    "AskAway": "976052223358406656",
-    "KnowWhatIMeme": "950505761862189096"
-  });
 }
+
+const appIds = Object.freeze({
+  // "YouTubeTogether": "755600276941176913", 
+  "WatchTogether": "880218394199220334",  // 新的 YouTubeTogether
+  "PokerNight": "755827207812677713",
+  "Betrayal.io": "773336526917861400",
+  "Fishington.io": "814288819477020702",
+  "ChessInThePark": "832012774040141894",
+  "SketchyArtist": "879864070101172255",
+  "Awkword": "879863881349087252",
+  "DoodleCrew": "878067389634314250",
+  "SketchHeads": "902271654783242291",
+  "LetterLeague": "879863686565621790",
+  "WordSnacks": "879863976006127627",
+  "SpellCast": "852509694341283871",
+  "CheckersInThePark": "832013003968348200",
+  "Blazing8s": "832025144389533716",
+  "PuttParty": "945737671223947305",
+  "Land-io": "903769130790969345",
+  "BobbleLeague": "947957217959759964",
+  "AskAway": "976052223358406656",
+  "KnowWhatIMeme": "950505761862189096"
+});


### PR DESCRIPTION
## 說明
根據主要開發團隊的意見，讓用戶可以使用所有的 activity

## 更改說明
- 重命名 Youtube 指令為 Activity
- 為了 backward compatible，參數為 optional，不提供時開啓 WatchTogether
- Activity 指令保留 `youtube` 和 `yt` 做為別名
- 舊的 YoutubeTogether 已經不能用了所以註解掉