### PR TITLE
chore: fix wrong class name

### DIFF
--- a/src/commands/Dmuser.ts
+++ b/src/commands/Dmuser.ts
@@ -23,7 +23,7 @@ import { Command } from "../classes/Command";
 import { Source } from "../classes/Source";
 import { CommandType } from "../utils/enums";
 
-export default class Dice extends Command<[User, string]> {
+export default class Dmuser extends Command<[User, string]> {
   constructor() {
     super({
       type: CommandType.Developer, 


### PR DESCRIPTION
## Change
* Fix wrong class name ([Dmuser.ts](./src/commands/Dmuser.ts)) (869971a)
```ts
// before change
export default class Dice extends Command<[User, string]> {}

// after change
export default class Dmuser extends Command<[User, string]>{}
```

然後我不知道為什麼，上一次 pr 後的東西拉回去我的 fork 會跳 conflict ，接著上一次 commit 的紀錄又跳上來，所以我用了重新 clone 一份自己已經更新成此專案最近一次 commit 的 fork  ，目前看來是沒有什麼問題。