### PR TITLE
chore: update required engine version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/src/index.js",
   "private": true,
   "engines": {
-    "node": ">=16.9.0"
+    "node": "^18.2.1"
   },
   "scripts": {
     "dev": "tsc-watch --onSuccess resolve-tspaths",


### PR DESCRIPTION
## 更改
因為現在 node 的 LTS 版本升級到 v18.12.1 了，所以將 package.json 的要求版本也改為 18.12.1。

另外，也增加了 .npmrc 用來強制實施。

## 其它資訊
tsc 不會叫，start 可以好好跑