### PR TITLE
chore: rename SelectMenu* to StringSelectMenu*

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@discordjs/voice": "^0.13.0",
         "@hizollo/games": "^2.4.0",
         "@hizollo/osu-api": "^1.2.0",
-        "discord.js": "^14.6.0",
+        "discord.js": "^14.7.1",
         "dotenv": "^16.0.3",
         "emoji-regex": "^10.2.1",
         "ffmpeg-static": "^5.1.0",
@@ -43,42 +43,42 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.3.0.tgz",
-      "integrity": "sha512-Pvca6Nw8Hp+n3N+Wp17xjygXmMvggbh5ywUsOYE2Et4xkwwVRwgzxDJiMUuYapPtnYt4w/8aKlf5khc8ipLvhg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.4.0.tgz",
+      "integrity": "sha512-nEeTCheTTDw5kO93faM1j8ZJPonAX86qpq/QVoznnSa8WWcCgJpjlu6GylfINTDW6o7zZY0my2SYdxx2mfNwGA==",
       "dependencies": {
         "@discordjs/util": "^0.1.0",
-        "@sapphire/shapeshift": "^3.7.0",
-        "discord-api-types": "^0.37.12",
+        "@sapphire/shapeshift": "^3.7.1",
+        "discord-api-types": "^0.37.20",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.1",
-        "tslib": "^2.4.0"
+        "ts-mixer": "^6.0.2",
+        "tslib": "^2.4.1"
       },
       "engines": {
         "node": ">=16.9.0"
       }
     },
     "node_modules/@discordjs/collection": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.2.0.tgz",
-      "integrity": "sha512-VvrrtGb7vbfPHzbhGq9qZB5o8FOB+kfazrxdt0OtxzSkoBuw9dURMkCwWizZ00+rDpiK2HmLHBZX+y6JsG9khw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.3.0.tgz",
+      "integrity": "sha512-ylt2NyZ77bJbRij4h9u/wVy7qYw/aDqQLWnadjvDqW/WoWCxrsX6M3CIw9GVP5xcGCDxsrKj5e0r5evuFYwrKg==",
       "engines": {
         "node": ">=16.9.0"
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.3.0.tgz",
-      "integrity": "sha512-U6X5J+r/MxYpPTlHFuPxXEf92aKsBaD2teBC7sWkKILIr30O8c9+XshfL7KFBCavnAqS/qE+PF9fgRilO3N44g==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.5.0.tgz",
+      "integrity": "sha512-lXgNFqHnbmzp5u81W0+frdXN6Etf4EUi8FAPcWpSykKd8hmlWh1xy6BmE0bsJypU1pxohaA8lQCgp70NUI3uzA==",
       "dependencies": {
-        "@discordjs/collection": "^1.2.0",
+        "@discordjs/collection": "^1.3.0",
         "@discordjs/util": "^0.1.0",
         "@sapphire/async-queue": "^1.5.0",
         "@sapphire/snowflake": "^3.2.2",
-        "discord-api-types": "^0.37.12",
+        "discord-api-types": "^0.37.23",
         "file-type": "^18.0.0",
-        "tslib": "^2.4.0",
-        "undici": "^5.11.0"
+        "tslib": "^2.4.1",
+        "undici": "^5.13.0"
       },
       "engines": {
         "node": ">=16.9.0"
@@ -199,12 +199,12 @@
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.7.0.tgz",
-      "integrity": "sha512-A6vI1zJoxhjWo4grsxpBRBgk96SqSdjLX5WlzKp9H+bJbkM07mvwcbtbVAmUZHbi/OG3HLfiZ1rlw4BhH6tsBQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.8.1.tgz",
+      "integrity": "sha512-xG1oXXBhCjPKbxrRTlox9ddaZTvVpOhYLmKmApD/vIWOV1xEYXnpoFs68zHIZBGbqztq6FrUPNPerIrO1Hqeaw==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
-        "lodash.uniqwith": "^4.5.0"
+        "lodash": "^4.17.21"
       },
       "engines": {
         "node": ">=v14.0.0",
@@ -212,9 +212,9 @@
       }
     },
     "node_modules/@sapphire/snowflake": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.2.2.tgz",
-      "integrity": "sha512-ula2O0kpSZtX9rKXNeQMrHwNd7E4jPDJYUXmEGTFdMRfyfMw+FPyh04oKMjAiDuOi64bYgVkOV3MjK+loImFhQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.4.0.tgz",
+      "integrity": "sha512-zZxymtVO6zeXVMPds+6d7gv/OfnCc25M1Z+7ZLB0oPmeMTPeRWVPQSS16oDJy5ZsyCOLj7M6mbZml5gWXcVRNw==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -414,27 +414,27 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.19",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.19.tgz",
-      "integrity": "sha512-5dVUYJfxCh/RU/S4D7osG3H+Ntl0GBkANO6oVRl35Eo+cd/peoNUAmcSzLzQ9Fqu2RJ9+2vd7DVcqNqYjX38wQ=="
+      "version": "0.37.24",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.24.tgz",
+      "integrity": "sha512-1+Fb4huJCihdbkJLcq2p7nBmtlmAryNwjefT8wwJnL8c7bc7WA87Oaa5mbLe96QvZyfwnwRCDX40H0HhcVV50g=="
     },
     "node_modules/discord.js": {
-      "version": "14.6.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.6.0.tgz",
-      "integrity": "sha512-On1K7xpJZRe0KsziIaDih2ksYPhgxym/ZqV45i1f3yig4vUotikqs7qp5oXiTzQ/UTiNRCixUWFTh7vA1YBCqw==",
+      "version": "14.7.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.7.1.tgz",
+      "integrity": "sha512-1FECvqJJjjeYcjSm0IGMnPxLqja/pmG1B0W2l3lUY2Gi4KXiyTeQmU1IxWcbXHn2k+ytP587mMWqva2IA87EbA==",
       "dependencies": {
-        "@discordjs/builders": "^1.3.0",
-        "@discordjs/collection": "^1.2.0",
-        "@discordjs/rest": "^1.3.0",
+        "@discordjs/builders": "^1.4.0",
+        "@discordjs/collection": "^1.3.0",
+        "@discordjs/rest": "^1.4.0",
         "@discordjs/util": "^0.1.0",
         "@sapphire/snowflake": "^3.2.2",
         "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.37.12",
+        "discord-api-types": "^0.37.20",
         "fast-deep-equal": "^3.1.3",
         "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.4.0",
-        "undici": "^5.11.0",
-        "ws": "^8.9.0"
+        "tslib": "^2.4.1",
+        "undici": "^5.13.0",
+        "ws": "^8.11.0"
       },
       "engines": {
         "node": ">=16.9.0"
@@ -738,15 +738,15 @@
         "libsodium": "^0.7.0"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
-    },
-    "node_modules/lodash.uniqwith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
-      "integrity": "sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -1278,9 +1278,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
@@ -1300,9 +1300,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
-      "integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
+      "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -1374,36 +1374,36 @@
       }
     },
     "@discordjs/builders": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.3.0.tgz",
-      "integrity": "sha512-Pvca6Nw8Hp+n3N+Wp17xjygXmMvggbh5ywUsOYE2Et4xkwwVRwgzxDJiMUuYapPtnYt4w/8aKlf5khc8ipLvhg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.4.0.tgz",
+      "integrity": "sha512-nEeTCheTTDw5kO93faM1j8ZJPonAX86qpq/QVoznnSa8WWcCgJpjlu6GylfINTDW6o7zZY0my2SYdxx2mfNwGA==",
       "requires": {
         "@discordjs/util": "^0.1.0",
-        "@sapphire/shapeshift": "^3.7.0",
-        "discord-api-types": "^0.37.12",
+        "@sapphire/shapeshift": "^3.7.1",
+        "discord-api-types": "^0.37.20",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.1",
-        "tslib": "^2.4.0"
+        "ts-mixer": "^6.0.2",
+        "tslib": "^2.4.1"
       }
     },
     "@discordjs/collection": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.2.0.tgz",
-      "integrity": "sha512-VvrrtGb7vbfPHzbhGq9qZB5o8FOB+kfazrxdt0OtxzSkoBuw9dURMkCwWizZ00+rDpiK2HmLHBZX+y6JsG9khw=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.3.0.tgz",
+      "integrity": "sha512-ylt2NyZ77bJbRij4h9u/wVy7qYw/aDqQLWnadjvDqW/WoWCxrsX6M3CIw9GVP5xcGCDxsrKj5e0r5evuFYwrKg=="
     },
     "@discordjs/rest": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.3.0.tgz",
-      "integrity": "sha512-U6X5J+r/MxYpPTlHFuPxXEf92aKsBaD2teBC7sWkKILIr30O8c9+XshfL7KFBCavnAqS/qE+PF9fgRilO3N44g==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.5.0.tgz",
+      "integrity": "sha512-lXgNFqHnbmzp5u81W0+frdXN6Etf4EUi8FAPcWpSykKd8hmlWh1xy6BmE0bsJypU1pxohaA8lQCgp70NUI3uzA==",
       "requires": {
-        "@discordjs/collection": "^1.2.0",
+        "@discordjs/collection": "^1.3.0",
         "@discordjs/util": "^0.1.0",
         "@sapphire/async-queue": "^1.5.0",
         "@sapphire/snowflake": "^3.2.2",
-        "discord-api-types": "^0.37.12",
+        "discord-api-types": "^0.37.23",
         "file-type": "^18.0.0",
-        "tslib": "^2.4.0",
-        "undici": "^5.11.0"
+        "tslib": "^2.4.1",
+        "undici": "^5.13.0"
       }
     },
     "@discordjs/util": {
@@ -1498,18 +1498,18 @@
       "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA=="
     },
     "@sapphire/shapeshift": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.7.0.tgz",
-      "integrity": "sha512-A6vI1zJoxhjWo4grsxpBRBgk96SqSdjLX5WlzKp9H+bJbkM07mvwcbtbVAmUZHbi/OG3HLfiZ1rlw4BhH6tsBQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.8.1.tgz",
+      "integrity": "sha512-xG1oXXBhCjPKbxrRTlox9ddaZTvVpOhYLmKmApD/vIWOV1xEYXnpoFs68zHIZBGbqztq6FrUPNPerIrO1Hqeaw==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
-        "lodash.uniqwith": "^4.5.0"
+        "lodash": "^4.17.21"
       }
     },
     "@sapphire/snowflake": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.2.2.tgz",
-      "integrity": "sha512-ula2O0kpSZtX9rKXNeQMrHwNd7E4jPDJYUXmEGTFdMRfyfMw+FPyh04oKMjAiDuOi64bYgVkOV3MjK+loImFhQ=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.4.0.tgz",
+      "integrity": "sha512-zZxymtVO6zeXVMPds+6d7gv/OfnCc25M1Z+7ZLB0oPmeMTPeRWVPQSS16oDJy5ZsyCOLj7M6mbZml5gWXcVRNw=="
     },
     "@tokenizer/token": {
       "version": "0.3.0",
@@ -1664,27 +1664,27 @@
       }
     },
     "discord-api-types": {
-      "version": "0.37.19",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.19.tgz",
-      "integrity": "sha512-5dVUYJfxCh/RU/S4D7osG3H+Ntl0GBkANO6oVRl35Eo+cd/peoNUAmcSzLzQ9Fqu2RJ9+2vd7DVcqNqYjX38wQ=="
+      "version": "0.37.24",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.24.tgz",
+      "integrity": "sha512-1+Fb4huJCihdbkJLcq2p7nBmtlmAryNwjefT8wwJnL8c7bc7WA87Oaa5mbLe96QvZyfwnwRCDX40H0HhcVV50g=="
     },
     "discord.js": {
-      "version": "14.6.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.6.0.tgz",
-      "integrity": "sha512-On1K7xpJZRe0KsziIaDih2ksYPhgxym/ZqV45i1f3yig4vUotikqs7qp5oXiTzQ/UTiNRCixUWFTh7vA1YBCqw==",
+      "version": "14.7.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.7.1.tgz",
+      "integrity": "sha512-1FECvqJJjjeYcjSm0IGMnPxLqja/pmG1B0W2l3lUY2Gi4KXiyTeQmU1IxWcbXHn2k+ytP587mMWqva2IA87EbA==",
       "requires": {
-        "@discordjs/builders": "^1.3.0",
-        "@discordjs/collection": "^1.2.0",
-        "@discordjs/rest": "^1.3.0",
+        "@discordjs/builders": "^1.4.0",
+        "@discordjs/collection": "^1.3.0",
+        "@discordjs/rest": "^1.4.0",
         "@discordjs/util": "^0.1.0",
         "@sapphire/snowflake": "^3.2.2",
         "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.37.12",
+        "discord-api-types": "^0.37.20",
         "fast-deep-equal": "^3.1.3",
         "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.4.0",
-        "undici": "^5.11.0",
-        "ws": "^8.9.0"
+        "tslib": "^2.4.1",
+        "undici": "^5.13.0",
+        "ws": "^8.11.0"
       }
     },
     "dotenv": {
@@ -1918,15 +1918,15 @@
         "libsodium": "^0.7.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "lodash.snakecase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
-    },
-    "lodash.uniqwith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
-      "integrity": "sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q=="
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -2263,9 +2263,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "typedarray": {
       "version": "0.0.6",
@@ -2278,9 +2278,9 @@
       "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA=="
     },
     "undici": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
-      "integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
+      "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
       "requires": {
         "busboy": "^1.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@discordjs/voice": "^0.13.0",
     "@hizollo/games": "^2.4.0",
     "@hizollo/osu-api": "^1.2.0",
-    "discord.js": "^14.6.0",
+    "discord.js": "^14.7.1",
     "dotenv": "^16.0.3",
     "emoji-regex": "^10.2.1",
     "ffmpeg-static": "^5.1.0",

--- a/src/classes/SelectMenuManager.ts
+++ b/src/classes/SelectMenuManager.ts
@@ -18,7 +18,7 @@
  * along with Junior HiZollo. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Interaction, InteractionType, SelectMenuInteraction } from 'discord.js';
+import { Interaction, InteractionType, StringSelectMenuInteraction } from 'discord.js';
 import fs from "node:fs";
 import path from "node:path";
 import constant from '@root/constant.json';
@@ -36,7 +36,7 @@ export class SelectMenuManager {
   /**
    * 選單識別ID－回應方式的鍵值對
    */
-  private data: Map<string, (interaction: SelectMenuInteraction<"cached">) => Promise<void>>;
+  private data: Map<string, (interaction: StringSelectMenuInteraction<"cached">) => Promise<void>>;
   
   /**
    * 永久選單的回應是否已載入完畢
@@ -63,7 +63,7 @@ export class SelectMenuManager {
     const buttonFiles = fs.readdirSync(dirPath);
     for (const file of buttonFiles) {
       if (!file.endsWith('.js')) continue;
-      const func: (interaction: SelectMenuInteraction<"cached">) => Promise<void> = require(path.join(dirPath, file)).default;
+      const func: (interaction: StringSelectMenuInteraction<"cached">) => Promise<void> = require(path.join(dirPath, file)).default;
       this.data.set(file.slice(0, -3), func);
     }
 

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -18,7 +18,7 @@
  * along with Junior HiZollo. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { ActionRowBuilder, ApplicationCommandOptionChoiceData, ApplicationCommandOptionType, ButtonBuilder, Client, EmbedBuilder, GuildMember, InteractionReplyOptions, MessageCreateOptions, PermissionFlagsBits, SelectMenuBuilder, SelectMenuInteraction } from "discord.js";
+import { ActionRowBuilder, ApplicationCommandOptionChoiceData, ApplicationCommandOptionType, ButtonBuilder, Client, EmbedBuilder, GuildMember, InteractionReplyOptions, MessageCreateOptions, PermissionFlagsBits, StringSelectMenuBuilder, StringSelectMenuInteraction } from "discord.js";
 import config from "@root/config";
 import { Command } from "../classes/Command";
 import { Source } from "../classes/Source";
@@ -76,9 +76,9 @@ export default class Help extends Command<[string]> {
     };
   }
 
-  public getComponentsForAllTypes(): ActionRowBuilder<ButtonBuilder | SelectMenuBuilder>[] {
+  public getComponentsForAllTypes(): ActionRowBuilder<ButtonBuilder | StringSelectMenuBuilder>[] {
 
-    const menu = new SelectMenuBuilder()
+    const menu = new StringSelectMenuBuilder()
       .setCustomId('help_menu_main')
       .setPlaceholder('請選擇一個指令分類');
     
@@ -92,7 +92,7 @@ export default class Help extends Command<[string]> {
       });
     }
 
-    return [new ActionRowBuilder<SelectMenuBuilder>().addComponents(menu)];
+    return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu)];
   }
 
   public getEmbedsForAllTypes(source: Source): EmbedBuilder[] {
@@ -120,15 +120,15 @@ export default class Help extends Command<[string]> {
   }
 
   
-  public getMessageForType(interaction: SelectMenuInteraction<"cached">, type: CommandType): InteractionReplyOptions {
+  public getMessageForType(interaction: StringSelectMenuInteraction<"cached">, type: CommandType): InteractionReplyOptions {
     return {
       components: this.getComponentsForType(interaction, type), 
       embeds: this.getEmbedsForType(interaction, type)
     };
   }
 
-  public getComponentsForType(interaction: SelectMenuInteraction<"cached">, type: CommandType): ActionRowBuilder<ButtonBuilder | SelectMenuBuilder>[] {
-    const menu = new SelectMenuBuilder()
+  public getComponentsForType(interaction: StringSelectMenuInteraction<"cached">, type: CommandType): ActionRowBuilder<ButtonBuilder | StringSelectMenuBuilder>[] {
+    const menu = new StringSelectMenuBuilder()
       .setCustomId('help_menu_type')
       .setPlaceholder('請選擇一個指令');
     const commands = type === CommandType.SubcommandGroup ?
@@ -144,10 +144,10 @@ export default class Help extends Command<[string]> {
       })
     });
 
-    return [new ActionRowBuilder<SelectMenuBuilder>().addComponents(menu)];
+    return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu)];
   }
 
-  public getEmbedsForType(interaction: SelectMenuInteraction<"cached">, type: CommandType): EmbedBuilder[] {
+  public getEmbedsForType(interaction: StringSelectMenuInteraction<"cached">, type: CommandType): EmbedBuilder[] {
     let description =
       `以下是所有**${Translator.getCommandTypeChinese(type)}**分類中的指令\n` +
       `你可以使用 \`${config.bot.prefix}help 指令名稱\` 或 \`/help 指令名稱\` 來查看特定指令的使用方法\n\n`;

--- a/src/features/utils/pageSystem.ts
+++ b/src/features/utils/pageSystem.ts
@@ -18,8 +18,7 @@
  * along with Junior HiZollo. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { ActionRowBuilder, SelectMenuBuilder } from '@discordjs/builders';
-import { APISelectMenuOption, ButtonBuilder, ButtonStyle, ComponentType, InteractionCollector, SelectMenuInteraction } from 'discord.js';
+import { ActionRowBuilder, APISelectMenuOption, ButtonBuilder, ButtonStyle, ComponentType, InteractionCollector, StringSelectMenuBuilder, StringSelectMenuInteraction } from 'discord.js';
 import { PageSystemMode } from '../../utils/enums.js';
 import { PageSystemDescriptionOptions, PageSystemEmbedFieldOptions, PageSystemPagesOptions } from '../../utils/interfaces.js';
 import { PageSystemOptions } from '../../utils/types.js';
@@ -109,7 +108,7 @@ export default async function pageSystem(options: PageSystemOptions): Promise<Pa
     });
   });
 
-  let selectCollector: InteractionCollector<SelectMenuInteraction>;
+  let selectCollector: InteractionCollector<StringSelectMenuInteraction>;
   if (allowSelect) {
     selectCollector = message.createMessageComponentCollector({
       filter: async i => {
@@ -187,7 +186,7 @@ function modifyButtons(actionRow: ActionRowBuilder<ButtonBuilder>, pageCount: nu
  * @param option 所有選項
  * @returns 動作列
  */
-function newSelectMenu(option: PageSystemPagesOptions[]): ActionRowBuilder<SelectMenuBuilder> {
+function newSelectMenu(option: PageSystemPagesOptions[]): ActionRowBuilder<StringSelectMenuBuilder> {
   const selectOptions: APISelectMenuOption[] = [];
   for (let i = 0; i < option.length; i++) {
     selectOptions.push({
@@ -196,11 +195,11 @@ function newSelectMenu(option: PageSystemPagesOptions[]): ActionRowBuilder<Selec
     })
   }
 
-  const select = new SelectMenuBuilder()
+  const select = new StringSelectMenuBuilder()
     .setCustomId('pageSystemSelect')
     .setPlaceholder('請選擇一個選項')
     .setOptions(selectOptions);
-  return new ActionRowBuilder<SelectMenuBuilder>().addComponents(select);
+  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
 }
 
 /**

--- a/src/selectmenus/help.ts
+++ b/src/selectmenus/help.ts
@@ -18,12 +18,12 @@
  * along with Junior HiZollo. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { SelectMenuInteraction } from "discord.js";
+import { StringSelectMenuInteraction } from "discord.js";
 import { Command } from "../classes/Command";
 import Help from "../commands/Help";
 import { SubcommandGroup } from "../utils/interfaces";
 
-export default async function help(interaction: SelectMenuInteraction<"cached">): Promise<void> {
+export default async function help(interaction: StringSelectMenuInteraction<"cached">): Promise<void> {
   const help = interaction.client.commands.search(['help', undefined]) as Help;
   const scope = interaction.customId.slice('help_menu_'.length);
   const selected = interaction.values[0];


### PR DESCRIPTION
## 摘要
將 `discord.js` 再升級到了 v14.7.1，而這個版本 `SelectMenuInteraction` 等物件被改名為 `StringSelectMenuInteraction` 了，所以也將他們更名為正確的名稱。

## 說明
如果有我沒發現的，還在使用原本名稱的檔案，請告訴我。