### PR TITLE
remove none-mfa guild restrict of hizollo

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,16 +1,16 @@
 /*
- * 
+ *
  * Copyright 2022 HiZollo Dev Team <https://github.com/hizollo>
- * 
+ *
  * This file is a part of Junior HiZollo.
- * 
- * Junior HiZollo is free software: you can redistribute it and/or 
+ *
+ * Junior HiZollo is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
- * Junior HiZollo is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ *
+ * Junior HiZollo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
@@ -33,10 +33,10 @@ import { HZClient } from './classes/HZClient';
 import { CommandManagerRejectReason, CommandParserOptionResultStatus } from './typings/enums';
 const client = new HZClient({
   intents: [
-    GatewayIntentBits.Guilds, 
-    GatewayIntentBits.GuildMessages, 
-    GatewayIntentBits.GuildMessageReactions, 
-    GatewayIntentBits.GuildVoiceStates, 
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.GuildMessageReactions,
+    GatewayIntentBits.GuildVoiceStates,
     GatewayIntentBits.MessageContent
   ],
   makeCache: Options.cacheWithLimits({
@@ -73,37 +73,32 @@ client.commands.on('reject', async (source, info) => {
       helper.setTitle('(ﾒﾟДﾟ)ﾒ')
         .setDescription(`你就是剛剛丟我的那個人！我才不想理你勒，你 ${~~(info.args[0] / 1000)} 秒之後再來跟我談！`);
       break;
-    
-    case CommandManagerRejectReason.TwoFactorRequird:
-      helper.setTitle('2FA 不讓我執行這個指令')
-        .setDescription(`因為這個伺服器開啟了 2FA 驗證，所以我無法執行這個指令`);
-      break;
-    
+
     case CommandManagerRejectReason.UserMissingPermission:
       helper.setTitle('你被權限之神禁錮了')
         .setDescription(`以下是你缺少的權限\n\n${info.args[0].map(perm => `- ${Translator.getPermissionChinese(perm)}`).join('\n')}`);
       break;
-    
+
     case CommandManagerRejectReason.BotMissingPermission:
       helper.setTitle('給我這麼點權限怎麼夠我用')
         .setDescription(`我把我要的權限都列出來了，快點給我不然我沒辦法幫你執行這個指令\n\n${info.args[0].map(perm => `- ${Translator.getPermissionChinese(perm)}`).join('\n')}`);
       break;
-    
+
     case CommandManagerRejectReason.InCooldown:
       helper.setTitle('你太快了')
         .setDescription(`你必須在 ${~~(info.args[0] / 1000)} 秒後才能再使用此指令。`);
       break;
-    
+
     case CommandManagerRejectReason.InNetwork:
       helper.setTitle('這個地方不適合使用指令')
         .setDescription('在 HiZollo Network 的領域裡使用指令會發生相當嚴重的時空錯亂，你不會希望這件事發生的');
       break;
-    
+
     case CommandManagerRejectReason.IllegalArgument:
       const [commandName, options, { arg, index, status }] = info.args;
 
       let description = options.map((o, i) => {
-        const text = o.repeat ? new Array(2).fill(o.name).map((e, i) => e.replaceAll('%i', (i+1).toString())).join(' ') + ' ...' : o.name;
+        const text = o.repeat ? new Array(2).fill(o.name).map((e, i) => e.replaceAll('%i', (i + 1).toString())).join(' ') + ' ...' : o.name;
         const indexRange = o.repeat ? (source.isMessage() ? Infinity : 5) : 0;
         return index <= i && i <= index + indexRange ? `[${text}]` : text;
       }).join(' ');
@@ -115,14 +110,14 @@ client.commands.on('reject', async (source, info) => {
         case CommandParserOptionResultStatus.Required:
           helper.setTitle(`參數 ${displayName} 是必填的`);
           break;
-        
+
         case CommandParserOptionResultStatus.WrongFormat:
           helper.setTitle(`參數 ${displayName} 的格式錯誤`);
           description += `${arg} 不符合${Translator.getCommandOptionTypeChinese(options[index])}`;
           if (options[index].type === ApplicationCommandOptionType.Boolean) description += `（是或否）`;
           description += `的格式`;
           break;
-      
+
         case CommandParserOptionResultStatus.NotInChoices:
           if (!('choices' in info.args[2])) break;
           const { choices } = info.args[2];
@@ -130,28 +125,28 @@ client.commands.on('reject', async (source, info) => {
           helper.setTitle(`${arg} 並不在規定的選項內`)
           description += `參數 ${displayName} 必須是下列選項中的其中一個：\n${choicesString}`;
           break;
-              
+
         case CommandParserOptionResultStatus.ValueTooSmall:
           if (!('limit' in info.args[2])) break;
           ({ limit } = info.args[2]);
           helper.setTitle(`參數 ${displayName} 太小了`);
           description += `這個參數必須比 ${limit} 還要大，但你給了 ${arg}`;
           break;
-              
+
         case CommandParserOptionResultStatus.ValueTooLarge:
           if (!('limit' in info.args[2])) break;
           ({ limit } = info.args[2]);
           helper.setTitle(`參數 ${displayName} 太大了`);
           description += `這個參數必須比 ${limit} 還要小，但你給了 ${arg}`;
           break;
-        
+
         case CommandParserOptionResultStatus.LengthTooShort:
           if (!('limit' in info.args[2])) break;
           ({ limit } = info.args[2]);
           helper.setTitle(`參數 ${displayName} 太短了`);
           description += `這個參數的長度必須比 ${limit} 還要長，但你給的 ${arg} 的長度只有 ${(arg as string).length}`;
           break;
-      
+
         case CommandParserOptionResultStatus.LengthTooLong:
           if (!('limit' in info.args[2])) break;
           ({ limit } = info.args[2]);

--- a/src/buttons/buttonrole.ts
+++ b/src/buttons/buttonrole.ts
@@ -1,16 +1,16 @@
 /*
- * 
+ *
  * Copyright 2022 HiZollo Dev Team <https://github.com/hizollo>
- * 
+ *
  * This file is a part of Junior HiZollo.
- * 
- * Junior HiZollo is free software: you can redistribute it and/or 
+ *
+ * Junior HiZollo is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
- * Junior HiZollo is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ *
+ * Junior HiZollo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
@@ -18,15 +18,12 @@
  * along with Junior HiZollo. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { ButtonInteraction, GuildMemberRoleManager, GuildMFALevel } from "discord.js";
+import { ButtonInteraction, GuildMemberRoleManager } from "discord.js";
 
 export default async function buttonrole(interaction: ButtonInteraction<"cached">): Promise<void> {
   const roleId = interaction.customId.slice('buttonrole_'.length);
   const role = interaction.guild?.roles.resolve(roleId);
-  if (interaction.guild.mfaLevel === GuildMFALevel.Elevated) {
-    await interaction.reply({ content: '這個伺服器開啟了 2FA 驗證，因此我無法管理身分組', ephemeral: true });
-    return;
-  }
+
   if (!role?.editable) {
     await interaction.reply({ content: `我的權限不足，因此無法管理 ${role} 身分組`, ephemeral: true });
     return;

--- a/src/classes/ButtonManager.ts
+++ b/src/classes/ButtonManager.ts
@@ -1,16 +1,16 @@
 /*
- * 
+ *
  * Copyright 2022 HiZollo Dev Team <https://github.com/hizollo>
- * 
+ *
  * This file is a part of Junior HiZollo.
- * 
- * Junior HiZollo is free software: you can redistribute it and/or 
+ *
+ * Junior HiZollo is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
- * Junior HiZollo is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ *
+ * Junior HiZollo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
@@ -32,12 +32,12 @@ export class ButtonManager {
    * 機器人的 client
    */
   public client: HZClient;
-  
+
   /**
    * 按鈕識別ID－回應方式的鍵值對
    */
   private data: Map<string, (interaction: ButtonInteraction<"cached">) => Promise<void>>;
-  
+
   /**
    * 永久按鈕的回應是否已載入完畢
    */
@@ -58,7 +58,7 @@ export class ButtonManager {
    * @param dirPath 要載入的目標資料夾
    */
   public async load(dirPath: string): Promise<void> {
-    if (this.loaded) throw new Error('Autocomplete has already been loaded.');
+    if (this.loaded) throw new Error('Buttons have already been loaded.');
 
     const buttonFiles = fs.readdirSync(dirPath);
     for (const file of buttonFiles) {
@@ -78,7 +78,9 @@ export class ButtonManager {
     if (interaction.type !== InteractionType.MessageComponent || !interaction.isButton()) return;
     if (!interaction.inCachedGuild()) return;
     if (interaction.user.blocked) return;
-    if (this.client.devMode && interaction.guild.id !== constant.mainGuild.id) return;
+    if (this.client.devMode &&
+      interaction.guildId !== constant.mainGuild.id &&
+      interaction.guildId !== constant.devGuild.id) return;
 
     const [identifier] = interaction.customId.split('_');
     const action = this.data.get(identifier);

--- a/src/classes/Command.ts
+++ b/src/classes/Command.ts
@@ -1,16 +1,16 @@
 /*
- * 
+ *
  * Copyright 2022 HiZollo Dev Team <https://github.com/hizollo>
- * 
+ *
  * This file is a part of Junior HiZollo.
- * 
- * Junior HiZollo is free software: you can redistribute it and/or 
+ *
+ * Junior HiZollo is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
- * Junior HiZollo is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ *
+ * Junior HiZollo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
@@ -80,21 +80,16 @@ export abstract class Command<T = unknown> {
   public permissions?: CommandPermission;
 
   /**
-   * 是否需要 2FA 驗證才能執行指令
-   */
-  public twoFactorRequired?: boolean;
-
-  /**
    * 執行此指令
    * @param source 觸發指令的來源
    * @param args 指令的參數
    * @abstract
    */
-  public abstract execute(source: Source ,args?: T): Promise<void>;
+  public abstract execute(source: Source, args?: T): Promise<void>;
 
   /**
    * 建立一個指令
-   * @param options 
+   * @param options
    */
   constructor(options: CommandOptions) {
     this.type = options.type;
@@ -107,7 +102,6 @@ export abstract class Command<T = unknown> {
     this.argumentParseMethod = options.argumentParseMethod ?? { type: ArgumentParseType.Split, separator: ' ' };
     this.cooldown = options.cooldown;
     this.permissions = options.permissions;
-    this.twoFactorRequired = options.twoFactorRequired ?? false;
   }
 
   /**

--- a/src/classes/CommandManager.ts
+++ b/src/classes/CommandManager.ts
@@ -1,16 +1,16 @@
 /*
- * 
+ *
  * Copyright 2022 HiZollo Dev Team <https://github.com/hizollo>
- * 
+ *
  * This file is a part of Junior HiZollo.
- * 
- * Junior HiZollo is free software: you can redistribute it and/or 
+ *
+ * Junior HiZollo is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
- * Junior HiZollo is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ *
+ * Junior HiZollo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
@@ -21,7 +21,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { EventEmitter } from "node:events";
-import { Awaitable, Collection, GuildMFALevel, Interaction, Message, PermissionFlagsBits } from "discord.js";
+import { Awaitable, Collection, Interaction, Message, PermissionFlagsBits } from "discord.js";
 import { Command } from "./Command";
 import { CommandParser } from "./CommandParser";
 import { HZClient } from "./HZClient";
@@ -140,11 +140,6 @@ export class CommandManager extends EventEmitter {
     /**/
 
     /***** 檢查執行權限 *****/
-    if (command.twoFactorRequired && interaction.guild.mfaLevel === GuildMFALevel.Elevated) {
-      this.emit('reject', new Source(interaction, channel, member), { reason: CommandManagerRejectReason.TwoFactorRequird, args: [] });
-      return;
-    }
-
     const userMissing = missingPermissions(command.permissions?.user ?? [], channel, member);
     if (userMissing.length) {
       this.emit('reject', new Source(interaction, channel, member), { reason: CommandManagerRejectReason.UserMissingPermission, args: [userMissing] });
@@ -251,10 +246,6 @@ export class CommandManager extends EventEmitter {
     /**/
 
     /***** 檢查執行權限 *****/
-    if (command.twoFactorRequired && message.guild.mfaLevel === GuildMFALevel.Elevated) {
-      this.emit('reject', new Source(message, channel, member), { reason: CommandManagerRejectReason.TwoFactorRequird, args: [] });
-    }
-
     const userMissing = missingPermissions(command.permissions?.user ?? [], message.channel, message.member);
     if (userMissing.length) {
       this.emit('reject', new Source(message, channel, member), { reason: CommandManagerRejectReason.UserMissingPermission, args: [userMissing] });
@@ -327,12 +318,12 @@ export class CommandManager extends EventEmitter {
     return this.subcommands.search([first, second]);
   }
 
-	public each(fn: (value: Command, key: string, collection: Collection<string, Command>) => void): Collection<string, Command> {
-		return this.commands.each(fn);
+  public each(fn: (value: Command, key: string, collection: Collection<string, Command>) => void): Collection<string, Command> {
+    return this.commands.each(fn);
   }
 
   public map<T>(fn: (value: Command, key: string, collection: Collection<string, Command>) => T): T[] {
-		return this.commands.map(fn);
+    return this.commands.map(fn);
   }
 
 

--- a/src/classes/HZNetwork.ts
+++ b/src/classes/HZNetwork.ts
@@ -1,16 +1,16 @@
 /*
- * 
+ *
  * Copyright 2022 HiZollo Dev Team <https://github.com/hizollo>
- * 
+ *
  * This file is a part of Junior HiZollo.
- * 
- * Junior HiZollo is free software: you can redistribute it and/or 
+ *
+ * Junior HiZollo is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
- * Junior HiZollo is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ *
+ * Junior HiZollo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
@@ -18,7 +18,7 @@
  * along with Junior HiZollo. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Awaitable, Channel, ChannelType, EmbedBuilder, Guild, GuildMFALevel, Message, PermissionFlagsBits, TextChannel, Webhook, WebhookMessageCreateOptions } from "discord.js";
+import { Awaitable, Channel, ChannelType, EmbedBuilder, Guild, Message, PermissionFlagsBits, TextChannel, Webhook, WebhookMessageCreateOptions } from "discord.js";
 import { EventEmitter } from "node:events";
 import { HZClient } from "./HZClient";
 import config from "@root/config";
@@ -86,7 +86,7 @@ export class HZNetwork extends EventEmitter {
     for (const portNo of this.publicPortNo) {
       this.ports.set(portNo, new Map());
     }
-  
+
     const promises = this.client.channels.cache
       .filter((channel): channel is TextChannel => {
         if (channel.type !== ChannelType.GuildText) return false;
@@ -94,14 +94,14 @@ export class HZNetwork extends EventEmitter {
         return this.publicPortNo.has(channel.name.slice(config.bot.network.portPrefix.length));
       })
       .map(async channel => {
-        if (!(channel.guild.members.me?.permissions.has(PermissionFlagsBits.ManageWebhooks) && channel.guild.mfaLevel === GuildMFALevel.None)) return;
+        if (!channel.guild.members.me?.permissions.has(PermissionFlagsBits.ManageWebhooks)) return;
 
         const portNo = this.getPortNo(channel);
         if (!portNo) return;
         await this.registerChannel(portNo, channel, true);
       });
     await Promise.all(promises);
-    
+
     this.loaded = true;
     this.emit('loaded');
   }
@@ -174,7 +174,7 @@ export class HZNetwork extends EventEmitter {
 
     // 傳送訊息
     try {
-      await message.delete().catch(() => {});
+      await message.delete().catch(() => { });
 
       let finalMessage = '';
       if (reference.content?.length) finalMessage += `> **${reference.username}**：${reference.content}\n`;
@@ -259,7 +259,7 @@ export class HZNetwork extends EventEmitter {
    * @param guild 從 client#on('guildCreate') 得到的伺服器
    */
   public async onGuildCreate(guild: Guild): Promise<void> {
-    await guild.fetch().catch(() => {});
+    await guild.fetch().catch(() => { });
     guild.channels.cache.each(async channel => {
       const portNo = this.getPortNo(channel);
       if (channel.type === ChannelType.GuildText && portNo) {
@@ -273,7 +273,7 @@ export class HZNetwork extends EventEmitter {
    * @param guild 從 client#on('guildDelete') 得到的伺服器
    */
   public async onGuildDelete(guild: Guild): Promise<void> {
-    await guild.fetch().catch(() => {});
+    await guild.fetch().catch(() => { });
     guild.channels.cache.each(async channel => {
       const portNo = this.getPortNo(channel);
       if (channel.type === ChannelType.GuildText && portNo) {
@@ -289,7 +289,7 @@ export class HZNetwork extends EventEmitter {
    * @param isBroadcast 是否為官方全頻公告
    */
   public async crosspost(portNo: string, options: WebhookMessageCreateOptions, isBroadcast?: boolean): Promise<void> {
-    await this.client.shard?.broadcastEval(async (client, {portNo, options}) => {
+    await this.client.shard?.broadcastEval(async (client, { portNo, options }) => {
       const webhooks = client.network.ports.get(portNo);
       if (!webhooks) return;
 
@@ -315,7 +315,7 @@ export class HZNetwork extends EventEmitter {
    * @returns 原有或新建立的 webhook，可能因為機器人權限不足而無法註冊
    */
   private async registerChannel(portNo: string, channel: TextChannel, isInitialize?: boolean): Promise<Webhook | void> {
-    const webhooks = await channel.fetchWebhooks().catch(() => {});
+    const webhooks = await channel.fetchWebhooks().catch(() => { });
     if (!webhooks) return;
 
     const hznHooks = webhooks.filter(hook => hook.name === this.webhookFormat(portNo));
@@ -323,7 +323,7 @@ export class HZNetwork extends EventEmitter {
     let hook: Webhook;
     if (!hznHooks.size) {
       hook = await channel.createWebhook({
-        name: this.webhookFormat(portNo), 
+        name: this.webhookFormat(portNo),
         avatar: this.client.user?.displayAvatarURL(),
         reason: '建立 HiZollo 聯絡網'
       });

--- a/src/classes/SelectMenuManager.ts
+++ b/src/classes/SelectMenuManager.ts
@@ -1,16 +1,16 @@
 /*
- * 
+ *
  * Copyright 2022 HiZollo Dev Team <https://github.com/hizollo>
- * 
+ *
  * This file is a part of Junior HiZollo.
- * 
- * Junior HiZollo is free software: you can redistribute it and/or 
+ *
+ * Junior HiZollo is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
- * Junior HiZollo is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ *
+ * Junior HiZollo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
@@ -32,12 +32,12 @@ export class SelectMenuManager {
    * 機器人的 client
    */
   public client: HZClient;
-  
+
   /**
    * 選單識別ID－回應方式的鍵值對
    */
   private data: Map<string, (interaction: AnySelectMenuInteraction<"cached">) => Promise<void>>;
-  
+
   /**
    * 永久選單的回應是否已載入完畢
    */
@@ -58,7 +58,7 @@ export class SelectMenuManager {
    * @param dirPath 要載入的目標資料夾
    */
   public async load(dirPath: string): Promise<void> {
-    if (this.loaded) throw new Error('Autocomplete has already been loaded.');
+    if (this.loaded) throw new Error('Selectmenus have already been loaded.');
 
     const buttonFiles = fs.readdirSync(dirPath);
     for (const file of buttonFiles) {
@@ -78,7 +78,9 @@ export class SelectMenuManager {
     if (interaction.type !== InteractionType.MessageComponent || !interaction.isAnySelectMenu()) return;
     if (!interaction.inCachedGuild()) return;
     if (interaction.user.blocked) return;
-    if (this.client.devMode && interaction.guild.id !== constant.mainGuild.id) return;
+    if (this.client.devMode &&
+      interaction.guildId !== constant.mainGuild.id &&
+      interaction.guildId !== constant.devGuild.id) return;
 
     const [identifier] = interaction.customId.split('_');
     const action = this.data.get(identifier);

--- a/src/commands/Buttonrole.ts
+++ b/src/commands/Buttonrole.ts
@@ -1,16 +1,16 @@
 /*
- * 
+ *
  * Copyright 2022 HiZollo Dev Team <https://github.com/hizollo>
- * 
+ *
  * This file is a part of Junior HiZollo.
- * 
- * Junior HiZollo is free software: you can redistribute it and/or 
+ *
+ * Junior HiZollo is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
- * Junior HiZollo is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ *
+ * Junior HiZollo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
@@ -25,10 +25,10 @@ import { Source } from "../classes/Source";
 import { CommandOptionType, CommandType } from "../typings/enums";
 
 type RoleData = {
-  id: string, 
-  name: string, 
-  style: ButtonStyle, 
-  description: string | null, 
+  id: string,
+  name: string,
+  style: ButtonStyle,
+  description: string | null,
   emoji: string | null
 };
 
@@ -39,54 +39,53 @@ enum ButtonroleAction {
 export default class Buttonrole extends Command<[Role, string, string, string]> {
   constructor() {
     super({
-      type: CommandType.Utility, 
-      name: 'buttonrole', 
-      description: '產生手動取得身分組的按鈕', 
+      type: CommandType.Utility,
+      name: 'buttonrole',
+      description: '產生手動取得身分組的按鈕',
       extraDescription:
-        '如果上一則訊息是由這個指令觸發的，再次使用這個指令後，新的按鈕會併入上一則訊息中，一則訊息最多可以擁有 5 個按鈕\n'+
-        '如果上一則訊息已經存在指定身分組的按鈕，會更新或移除該按鈕：\n'+
-        '當你輸入的所有參數（描述、表情、顏色）都與訊息上的相同，該按鈕會被移除\n'+
-        '如果有至少一項參數是不同的，該按鈕的所有參數會被更新成你輸入的新參數', 
-      aliases: ['br'], 
-      options: [{ 
-        type: ApplicationCommandOptionType.Role, 
-        name: '身分組', 
-        description: '要添加的身分組', 
+        '如果上一則訊息是由這個指令觸發的，再次使用這個指令後，新的按鈕會併入上一則訊息中，一則訊息最多可以擁有 5 個按鈕\n' +
+        '如果上一則訊息已經存在指定身分組的按鈕，會更新或移除該按鈕：\n' +
+        '當你輸入的所有參數（描述、表情、顏色）都與訊息上的相同，該按鈕會被移除\n' +
+        '如果有至少一項參數是不同的，該按鈕的所有參數會被更新成你輸入的新參數',
+      aliases: ['br'],
+      options: [{
+        type: ApplicationCommandOptionType.Role,
+        name: '身分組',
+        description: '要添加的身分組',
         required: true
       }, {
-        type: ApplicationCommandOptionType.String, 
-        name: '描述', 
-        description: '簡單描述這個身分組', 
+        type: ApplicationCommandOptionType.String,
+        name: '描述',
+        description: '簡單描述這個身分組',
         required: false
       }, {
-        type: ApplicationCommandOptionType.String, 
-        parseAs: CommandOptionType.Emoji, 
-        name: '表情', 
-        description: '對應按鈕的表情符號', 
+        type: ApplicationCommandOptionType.String,
+        parseAs: CommandOptionType.Emoji,
+        name: '表情',
+        description: '對應按鈕的表情符號',
         required: false
       }, {
-        type: ApplicationCommandOptionType.String, 
-        name: '顏色', 
-        description: '對應按鈕的顏色', 
+        type: ApplicationCommandOptionType.String,
+        name: '顏色',
+        description: '對應按鈕的顏色',
         choices: [
-          { name: "藍", value: `${ButtonStyle.Primary}` }, 
-          { name: "灰", value: `${ButtonStyle.Secondary}` }, 
-          { name: "綠", value: `${ButtonStyle.Success}` }, 
+          { name: "藍", value: `${ButtonStyle.Primary}` },
+          { name: "灰", value: `${ButtonStyle.Secondary}` },
+          { name: "綠", value: `${ButtonStyle.Success}` },
           { name: "紅", value: `${ButtonStyle.Danger}` }
-        ], 
+        ],
         required: false
       }],
       permissions: {
         bot: [PermissionFlagsBits.ManageRoles, PermissionFlagsBits.ReadMessageHistory, PermissionFlagsBits.SendMessages, PermissionFlagsBits.ViewChannel],
         user: [PermissionFlagsBits.ManageRoles]
-      }, 
-      twoFactorRequired: true
+      }
     });
   }
 
   public async execute(source: Source, [role, description, emoji, style]: [Role, string, string, string]): Promise<void> {
     await source.hide();
-      
+
     const memberRoles = source.member?.roles;
     if (!(memberRoles && 'highest' in memberRoles)) {
       await source.temp('你需要在伺服器中才能使用這個指令');
@@ -122,17 +121,17 @@ export default class Buttonrole extends Command<[Role, string, string, string]> 
       }
       else {
         roles.push({
-          id: role.id, 
-          name: role.name, 
-          style: this.resolveStyle(style), 
-          emoji: emoji, 
+          id: role.id,
+          name: role.name,
+          style: this.resolveStyle(style),
+          emoji: emoji,
           description: description
         });
         action = ButtonroleAction.Add;
       }
 
       if (roles.length === 0) {
-        await message.delete().catch(() => {});
+        await message.delete().catch(() => { });
         await source.temp(`成功移除 ${role.name} 的按鈕`);
         return;
       }
@@ -141,18 +140,18 @@ export default class Buttonrole extends Command<[Role, string, string, string]> 
         return;
       }
 
-      await message.edit({ 
+      await message.edit({
         allowedMentions: { parse: [] },
-        components: [this.getActionRow(roles)], 
+        components: [this.getActionRow(roles)],
         content: this.getContent(roles)
       }).then(async () => {
         switch (action) {
           case ButtonroleAction.Add:
             return await source.temp(`成功加上 ${role.name} 的按鈕`);
-          
+
           case ButtonroleAction.Update:
             return await source.temp(`成功更新 ${role.name} 的按鈕`);
-          
+
           case ButtonroleAction.Remove:
             return await source.temp(`成功移除 ${role.name} 的按鈕`);
         }
@@ -162,10 +161,10 @@ export default class Buttonrole extends Command<[Role, string, string, string]> 
     }
     else {
       this.send(source, {
-        id: role.id, 
-        name: role.name, 
-        style: this.resolveStyle(style), 
-        emoji: emoji, 
+        id: role.id,
+        name: role.name,
+        style: this.resolveStyle(style),
+        emoji: emoji,
         description: description
       });
     }
@@ -174,7 +173,7 @@ export default class Buttonrole extends Command<[Role, string, string, string]> 
   private async send(source: Source, role: RoleData): Promise<void> {
     source.channel?.send({
       allowedMentions: { parse: [] },
-      components: [this.getActionRow([role])], 
+      components: [this.getActionRow([role])],
       content: this.getContent([role])
     }).then(async () => {
       await source.temp(`成功建立 ${role.name} 的按鈕`);
@@ -193,10 +192,10 @@ export default class Buttonrole extends Command<[Role, string, string, string]> 
     const roles: RoleData[] = [];
     for (const button of message.components[0].components as ButtonComponent[]) {
       roles.push({
-        id: button.customId!.slice('buttonrole_'.length), 
-        name: button.label!, 
-        style: button.style, 
-        description: null, 
+        id: button.customId!.slice('buttonrole_'.length),
+        name: button.label!,
+        style: button.style,
+        description: null,
         emoji: button.emoji?.id ?? button.emoji?.name ?? null
       });
     }
@@ -242,13 +241,13 @@ export default class Buttonrole extends Command<[Role, string, string, string]> 
   }
 
   private styleTable = {
-    '藍': ButtonStyle.Primary, 
-    '灰': ButtonStyle.Secondary, 
-    '綠': ButtonStyle.Success, 
-    '紅': ButtonStyle.Danger, 
-    [`${ButtonStyle.Primary}`]: ButtonStyle.Primary, 
-    [`${ButtonStyle.Secondary}`]: ButtonStyle.Secondary, 
-    [`${ButtonStyle.Success}`]: ButtonStyle.Success, 
+    '藍': ButtonStyle.Primary,
+    '灰': ButtonStyle.Secondary,
+    '綠': ButtonStyle.Success,
+    '紅': ButtonStyle.Danger,
+    [`${ButtonStyle.Primary}`]: ButtonStyle.Primary,
+    [`${ButtonStyle.Secondary}`]: ButtonStyle.Secondary,
+    [`${ButtonStyle.Success}`]: ButtonStyle.Success,
     [`${ButtonStyle.Danger}`]: ButtonStyle.Danger
   }
 }

--- a/src/commands/Deletemsg.ts
+++ b/src/commands/Deletemsg.ts
@@ -1,16 +1,16 @@
 /*
- * 
+ *
  * Copyright 2022 HiZollo Dev Team <https://github.com/hizollo>
- * 
+ *
  * This file is a part of Junior HiZollo.
- * 
- * Junior HiZollo is free software: you can redistribute it and/or 
+ *
+ * Junior HiZollo is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
- * Junior HiZollo is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ *
+ * Junior HiZollo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
@@ -25,28 +25,27 @@ import { CommandType } from "../typings/enums";
 
 export default class Deletemsg extends Command<[number]> {
   constructor() {
-    super({ 
-      type: CommandType.Utility, 
-      name: 'deletemsg', 
-      description: `在指定時間後刪除此指令的前一則訊息`, 
+    super({
+      type: CommandType.Utility,
+      name: 'deletemsg',
+      description: `在指定時間後刪除此指令的前一則訊息`,
       options: [{
-        type: ApplicationCommandOptionType.Number, 
-        name: '時間', 
-        description: '多久後刪除訊息，單位為秒', 
-        required: true, 
-        minValue: 1, 
+        type: ApplicationCommandOptionType.Number,
+        name: '時間',
+        description: '多久後刪除訊息，單位為秒',
+        required: true,
+        minValue: 1,
         maxValue: 120
       }],
       permissions: {
         bot: [PermissionFlagsBits.ManageMessages, PermissionFlagsBits.ReadMessageHistory, PermissionFlagsBits.ViewChannel],
         user: [PermissionFlagsBits.ManageMessages, PermissionFlagsBits.ReadMessageHistory, PermissionFlagsBits.ViewChannel]
-      }, 
-      twoFactorRequired: true
+      }
     });
   }
 
   public async execute(source: Source, [time]: [number]): Promise<void> {
-    const messages = await source.channel?.messages.fetch({ limit: source.isChatInput() ? 1 : 2 }).catch(() => {});
+    const messages = await source.channel?.messages.fetch({ limit: source.isChatInput() ? 1 : 2 }).catch(() => { });
     const message = messages?.first(-1)[0];
 
     await source.hide();
@@ -61,8 +60,8 @@ export default class Deletemsg extends Command<[number]> {
     }
 
     setTimeout(async () => {
-      await message.delete().catch(() => {});
+      await message.delete().catch(() => { });
       await source.temp('已刪除指定訊息');
-    }, time*1000);
+    }, time * 1000);
   }
 }

--- a/src/commands/Purge.ts
+++ b/src/commands/Purge.ts
@@ -1,16 +1,16 @@
 /*
- * 
+ *
  * Copyright 2022 HiZollo Dev Team <https://github.com/hizollo>
- * 
+ *
  * This file is a part of Junior HiZollo.
- * 
- * Junior HiZollo is free software: you can redistribute it and/or 
+ *
+ * Junior HiZollo is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
- * Junior HiZollo is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ *
+ * Junior HiZollo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
@@ -25,23 +25,22 @@ import { CommandType } from "../typings/enums";
 
 export default class Purge extends Command<[number]> {
   constructor() {
-    super({ 
-      type: CommandType.Utility, 
-      name: 'purge', 
-      description: '刪除頻道中指定數量的訊息', 
+    super({
+      type: CommandType.Utility,
+      name: 'purge',
+      description: '刪除頻道中指定數量的訊息',
       options: [{
-        type: ApplicationCommandOptionType.Integer, 
-        name: '數量', 
-        description: '要刪除的訊息數量', 
-        required: true, 
-        minValue: 1, 
+        type: ApplicationCommandOptionType.Integer,
+        name: '數量',
+        description: '要刪除的訊息數量',
+        required: true,
+        minValue: 1,
         maxValue: 99
-      }], 
+      }],
       permissions: {
-        bot: [PermissionFlagsBits.ManageMessages, PermissionFlagsBits.ReadMessageHistory, PermissionFlagsBits.ViewChannel], 
+        bot: [PermissionFlagsBits.ManageMessages, PermissionFlagsBits.ReadMessageHistory, PermissionFlagsBits.ViewChannel],
         user: [PermissionFlagsBits.ManageMessages, PermissionFlagsBits.ReadMessageHistory, PermissionFlagsBits.ViewChannel]
-      }, 
-      twoFactorRequired: true
+      }
     });
   }
 

--- a/src/typings/enums.ts
+++ b/src/typings/enums.ts
@@ -1,16 +1,16 @@
 /*
- * 
+ *
  * Copyright 2022 HiZollo Dev Team <https://github.com/hizollo>
- * 
+ *
  * This file is a part of Junior HiZollo.
- * 
- * Junior HiZollo is free software: you can redistribute it and/or 
+ *
+ * Junior HiZollo is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
- * Junior HiZollo is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ *
+ * Junior HiZollo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
@@ -19,53 +19,52 @@
  */
 
 export enum CommandParserOptionResultStatus {
-  Pass, 
-  Required, 
-  WrongFormat, 
-  NotInChoices, 
-  ValueTooSmall, 
-  ValueTooLarge, 
-  LengthTooShort, 
+  Pass,
+  Required,
+  WrongFormat,
+  NotInChoices,
+  ValueTooSmall,
+  ValueTooLarge,
+  LengthTooShort,
   LengthTooLong
 }
 
 export enum CommandManagerRejectReason {
-  Angry, 
-  TwoFactorRequird, 
-  BotMissingPermission, 
-  UserMissingPermission, 
-  InCooldown, 
-  InNetwork, 
+  Angry,
+  BotMissingPermission,
+  UserMissingPermission,
+  InCooldown,
+  InNetwork,
   IllegalArgument
 }
 
 export enum CommandType {
-  Fun, 
-  Utility, 
-  SinglePlayerGame, 
-  MultiPlayerGame, 
-  Information, 
-  SubcommandGroup, 
-  Contact, 
-  Network, 
-  Miscellaneous, 
+  Fun,
+  Utility,
+  SinglePlayerGame,
+  MultiPlayerGame,
+  Information,
+  SubcommandGroup,
+  Contact,
+  Network,
+  Miscellaneous,
   // 不管上面再多加幾個分類，Developer 永遠都要在最底端
   Developer
 }
 
 export enum CommandOptionType {
-  Subcommand, 
-  SubcommandGroup, 
-  String, 
-  Emoji, 
-  Integer, 
-  Boolean, 
-  User, 
-  Member, 
-  Channel, 
-  Role, 
-  Mentionable, 
-  Number, 
+  Subcommand,
+  SubcommandGroup,
+  String,
+  Emoji,
+  Integer,
+  Boolean,
+  User,
+  Member,
+  Channel,
+  Role,
+  Mentionable,
+  Number,
   Attachment
 };
 

--- a/src/typings/interfaces.ts
+++ b/src/typings/interfaces.ts
@@ -1,16 +1,16 @@
 /*
- * 
+ *
  * Copyright 2022 HiZollo Dev Team <https://github.com/hizollo>
- * 
+ *
  * This file is a part of Junior HiZollo.
- * 
- * Junior HiZollo is free software: you can redistribute it and/or 
+ *
+ * Junior HiZollo is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
- * Junior HiZollo is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ *
+ * Junior HiZollo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
@@ -96,7 +96,6 @@ export interface CommandOptions {
   argumentParseMethod?: ArgumentParseMethod;
   cooldown?: number;
   permissions?: CommandPermission;
-  twoFactorRequired?: boolean;
 }
 
 export interface CommandPermission {
@@ -124,7 +123,7 @@ export interface ModelSystemContentOptions {
 export interface ModelSystemOptions {
   source: Source;
   buttons: {
-    open: ButtonBuilder, 
+    open: ButtonBuilder,
     close: ButtonBuilder
   };
   modal: ModalBuilder;
@@ -141,7 +140,7 @@ export interface BasePageSystemOptions {
   thumbnails?: (string | null)[];
   extendFooter?: string;
   contents: {
-    exit: string, 
+    exit: string,
     idle: string
   };
 }

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -1,16 +1,16 @@
 /*
- * 
+ *
  * Copyright 2022 HiZollo Dev Team <https://github.com/hizollo>
- * 
+ *
  * This file is a part of Junior HiZollo.
- * 
- * Junior HiZollo is free software: you can redistribute it and/or 
+ *
+ * Junior HiZollo is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
- * Junior HiZollo is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ *
+ * Junior HiZollo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
@@ -36,7 +36,7 @@ export type Intersect<T, U> = { [K in (keyof T & keyof U)]: T[K] | U[K] };
 
 export type ValueOf<T> = T[keyof T];
 
-export type CommandParserOptionResult = 
+export type CommandParserOptionResult =
   | CommandParserOptionPassResult
   | CommandParserOptionFailWithPureStatusResult
   | CommandParserOptionFailWithChoicesResult
@@ -46,13 +46,12 @@ export type CommandParserPassResult = { args: unknown[] } & Omit<CommandParserOp
 
 export type CommandParserFailResult = { index: number } & Exclude<CommandParserOptionResult, CommandParserOptionPassResult>;
 
-export type CommandParserResult = 
+export type CommandParserResult =
   | CommandParserPassResult
   | CommandParserFailResult
 
-export type CommandManagerRejectInfo = 
+export type CommandManagerRejectInfo =
   | { reason: CommandManagerRejectReason.Angry, args: [time: number] }
-  | { reason: CommandManagerRejectReason.TwoFactorRequird, args: [] }
   | { reason: CommandManagerRejectReason.BotMissingPermission, args: [missings: (keyof PermissionFlags)[]] }
   | { reason: CommandManagerRejectReason.UserMissingPermission, args: [missings: (keyof PermissionFlags)[]] }
   | { reason: CommandManagerRejectReason.InCooldown, args: [time: number] }
@@ -64,7 +63,7 @@ export type HZCommandOptionData = (Exclude<ApplicationCommandOptionData,
   | ApplicationCommandSubGroupData
 > & { parseAs?: CommandOptionType, repeat?: boolean });
 
-export type ArgumentParseMethod = 
+export type ArgumentParseMethod =
   | { type: ArgumentParseType.None }
   | { type: ArgumentParseType.Split, separator: string }
   | { type: ArgumentParseType.Quote, quotes: [string, string] }
@@ -98,7 +97,7 @@ declare module "discord.js" {
      * 重要事件的記錄器
      */
     logger: WebhookLogger;
-    
+
     /**
      * 指令管家
      */


### PR DESCRIPTION
原本要擋開啓必須使用 MFA 才能管理的伺服器，現在已經過時了，所以把這些拿掉。

另外，加了一個 feature，讓測試模式時，devGuild 也能使用永久選單和按鈕。