### PR TITLE
更新套件版本並修復少量漏洞

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,25 +9,24 @@
       "version": "1.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@discordjs/voice": "^0.13.0",
+        "@discordjs/voice": "^0.17.0",
         "@hizollo/calculator": "^1.0.2",
         "@hizollo/games": "^2.5.0",
         "@hizollo/osu-api": "^1.2.0",
-        "axios": "^1.4.0",
-        "discord.js": "^14.13.0",
-        "dotenv": "^16.3.1",
-        "emoji-regex": "^10.2.1",
-        "ffmpeg-static": "^5.1.0",
-        "libsodium-wrappers": "^0.7.11",
-        "play-dl": "^1.9.6"
+        "discord.js": "^14.15.3",
+        "dotenv": "^16.4.5",
+        "emoji-regex": "^10.3.0",
+        "ffmpeg-static": "^5.2.0",
+        "libsodium-wrappers": "^0.7.15",
+        "play-dl": "^1.9.7"
       },
       "devDependencies": {
-        "resolve-tspaths": "^0.8.15",
-        "tsc-watch": "^6.0.4",
-        "typescript": "^5.2.2"
+        "resolve-tspaths": "^0.8.19",
+        "tsc-watch": "^6.2.0",
+        "typescript": "^5.4.5"
       },
       "engines": {
-        "node": "^18.2.1"
+        "node": ">=18.2.1"
       }
     },
     "node_modules/@derhuerst/http-basic": {
@@ -45,20 +44,23 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.5.tgz",
-      "integrity": "sha512-SdweyCs/+mHj+PNhGLLle7RrRFX9ZAhzynHahMCLqp5Zeq7np7XC6/mgzHc79QoVlQ1zZtOkTTiJpOZu5V8Ufg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.2.tgz",
+      "integrity": "sha512-6wvG3QaCjtMu0xnle4SoOIeFB4y6fKMN6WZfy3BMKJdQQtPLik8KGzDwBVL/+wTtcE/ZlFjgEk74GublyEVZ7g==",
       "dependencies": {
-        "@discordjs/formatters": "^0.3.2",
-        "@discordjs/util": "^1.0.1",
-        "@sapphire/shapeshift": "^3.9.2",
-        "discord-api-types": "0.37.50",
+        "@discordjs/formatters": "^0.4.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/shapeshift": "^3.9.7",
+        "discord-api-types": "0.37.83",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.3",
-        "tslib": "^2.6.1"
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/collection": {
@@ -70,75 +72,112 @@
       }
     },
     "node_modules/@discordjs/formatters": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.2.tgz",
-      "integrity": "sha512-lE++JZK8LSSDRM5nLjhuvWhGuKiXqu+JZ/DsOR89DVVia3z9fdCJVcHF2W/1Zxgq0re7kCzmAJlCMMX3tetKpA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.4.0.tgz",
+      "integrity": "sha512-fJ06TLC1NiruF35470q3Nr1bi95BdvKFAF+T5bNfZJ4bNdqZ3VZ+Ttg6SThqTxm6qumSG3choxLBHMC69WXNXQ==",
       "dependencies": {
-        "discord-api-types": "0.37.50"
+        "discord-api-types": "0.37.83"
       },
       "engines": {
         "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.0.1.tgz",
-      "integrity": "sha512-/eWAdDRvwX/rIE2tuQUmKaxmWeHmGealttIzGzlYfI4+a7y9b6ZoMp8BG/jaohs8D8iEnCNYaZiOFLVFLQb8Zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.0.tgz",
+      "integrity": "sha512-C1kAJK8aSYRv3ZwMG8cvrrW4GN0g5eMdP8AuN8ODH5DyOCbHgJspze1my3xHOAgwLJdKUbWNVyAeJ9cEdduqIg==",
       "dependencies": {
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/util": "^1.0.1",
-        "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.5.1",
-        "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.50",
-        "magic-bytes.js": "^1.0.15",
-        "tslib": "^2.6.1",
-        "undici": "5.22.1"
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "0.37.83",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.2",
+        "undici": "6.13.0"
       },
       "engines": {
         "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.0.tgz",
+      "integrity": "sha512-mLcTACtXUuVgutoznkh6hS3UFqYirDYAg5Dc1m8xn6OvPjetnUlf/xjtqnnc47OwWdaoCQnHmHh9KofhD6uRqw==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/util": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.1.tgz",
-      "integrity": "sha512-d0N2yCxB8r4bn00/hvFZwM7goDcUhtViC5un4hPj73Ba4yrChLSJD8fy7Ps5jpTLg1fE9n4K0xBLc1y9WGwSsA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.0.tgz",
+      "integrity": "sha512-IndcI5hzlNZ7GS96RV3Xw1R2kaDuXEp7tRIy/KlhidpN/BQ1qh1NZt3377dMLTa44xDUNKT7hnXkA/oUAzD/lg==",
       "engines": {
         "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/voice": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.13.0.tgz",
-      "integrity": "sha512-ZzwDmVINaLgkoDUeTJfpN9TkjINMLfTVoLMtEygm0YC5jTTw7AvKGqhc+Ae/2kNLywd0joyFVNrLp94yCkQ9SA==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.17.0.tgz",
+      "integrity": "sha512-hArn9FF5ZYi1IkxdJEVnJi+OxlwLV0NJYWpKXsmNOojtGtAZHxmsELA+MZlu2KW1F/K1/nt7lFOfcMXNYweq9w==",
       "dependencies": {
-        "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.37.12",
-        "prism-media": "^1.3.4",
-        "tslib": "^2.4.0",
-        "ws": "^8.9.0"
-      },
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
-    "node_modules/@discordjs/ws": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.1.tgz",
-      "integrity": "sha512-avvAolBqN3yrSvdBPcJ/0j2g42ABzrv3PEL76e3YTp2WYMGH7cuspkjfSyNWaqYl1J+669dlLp+YFMxSVQyS5g==",
-      "dependencies": {
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/rest": "^2.0.1",
-        "@discordjs/util": "^1.0.1",
-        "@sapphire/async-queue": "^1.5.0",
-        "@types/ws": "^8.5.5",
-        "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.50",
-        "tslib": "^2.6.1",
-        "ws": "^8.13.0"
+        "@types/ws": "^8.5.10",
+        "discord-api-types": "0.37.83",
+        "prism-media": "^1.3.5",
+        "tslib": "^2.6.2",
+        "ws": "^8.16.0"
       },
       "engines": {
         "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.1.tgz",
+      "integrity": "sha512-PZ+vLpxGCRtmr2RMkqh8Zp+BenUaJqlS6xhgWKEZcgC/vfHLEzpHtKkB0sl3nZWpwtcKk6YWy+pU3okL2I97FA==",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.3.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "0.37.83",
+        "tslib": "^2.6.2",
+        "ws": "^8.16.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.0.tgz",
+      "integrity": "sha512-mLcTACtXUuVgutoznkh6hS3UFqYirDYAg5Dc1m8xn6OvPjetnUlf/xjtqnnc47OwWdaoCQnHmHh9KofhD6uRqw==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@hizollo/calculator": {
@@ -216,31 +255,30 @@
       }
     },
     "node_modules/@sapphire/async-queue": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
-      "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.3.tgz",
+      "integrity": "sha512-x7zadcfJGxFka1Q3f8gCts1F0xMwCKbZweM85xECGI0hBTeIZJGGCrHgLggihBoprlQ/hBmDR5LKfIPqnmHM3w==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.2.tgz",
-      "integrity": "sha512-YRbCXWy969oGIdqR/wha62eX8GNHsvyYi0Rfd4rNW6tSVVa8p0ELiMEuOH/k8rgtvRoM+EMV7Csqz77YdwiDpA==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.7.tgz",
+      "integrity": "sha512-4It2mxPSr4OGn4HSQWGmhFMsNFGfFVhWeRPCRwbH972Ek2pzfGRZtb0pJ4Ze6oIzcyh2jw7nUDa6qGlWofgd9g==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "lodash": "^4.17.21"
       },
       "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=v16"
       }
     },
     "node_modules/@sapphire/snowflake": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
-      "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -252,17 +290,17 @@
       "integrity": "sha512-En7tneq+j0qAiVwysBD79y86MT3ModuoIJbe7JXp+sb5UAjInSShmK3nXXMioBzfF7rXC12hv12d4IyCVwN4dA=="
     },
     "node_modules/@types/ws": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
-      "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
+      "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.2.tgz",
-      "integrity": "sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
+      "integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -298,23 +336,13 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
-    "node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -324,17 +352,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -365,12 +382,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
       "dev": true,
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/component-emitter": {
@@ -445,43 +462,44 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.50",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
-      "integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
+      "version": "0.37.83",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.83.tgz",
+      "integrity": "sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA=="
     },
     "node_modules/discord.js": {
-      "version": "14.13.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.13.0.tgz",
-      "integrity": "sha512-Kufdvg7fpyTEwANGy9x7i4od4yu5c6gVddGi5CKm4Y5a6sF0VBODObI3o0Bh7TGCj0LfNT8Qp8z04wnLFzgnbA==",
+      "version": "14.15.3",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.3.tgz",
+      "integrity": "sha512-/UJDQO10VuU6wQPglA4kz2bw2ngeeSbogiIPx/TsnctfzV/tNf+q+i1HlgtX1OGpeOBpJH9erZQNO5oRM2uAtQ==",
       "dependencies": {
-        "@discordjs/builders": "^1.6.5",
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/formatters": "^0.3.2",
-        "@discordjs/rest": "^2.0.1",
-        "@discordjs/util": "^1.0.1",
-        "@discordjs/ws": "^1.0.1",
-        "@sapphire/snowflake": "^3.5.1",
-        "@types/ws": "^8.5.5",
-        "discord-api-types": "0.37.50",
-        "fast-deep-equal": "^3.1.3",
-        "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.6.1",
-        "undici": "5.22.1",
-        "ws": "^8.13.0"
+        "@discordjs/builders": "^1.8.2",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.4.0",
+        "@discordjs/rest": "^2.3.0",
+        "@discordjs/util": "^1.1.0",
+        "@discordjs/ws": "^1.1.1",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "0.37.83",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "tslib": "2.6.2",
+        "undici": "6.13.0"
       },
       "engines": {
         "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "engines": {
         "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/duplexer": {
@@ -491,9 +509,9 @@
       "dev": true
     },
     "node_modules/emoji-regex": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
-      "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA=="
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw=="
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
@@ -524,9 +542,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -545,18 +563,18 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
     },
     "node_modules/ffmpeg-static": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.1.0.tgz",
-      "integrity": "sha512-eEWOiGdbf7HKPeJI5PoJ0oCwkL0hckL2JdS4JOuB/gUETppwkEpq8nF0+e6VEQnDCo/iuoipbTUsn9QJmtpNkg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.2.0.tgz",
+      "integrity": "sha512-WrM7kLW+do9HLr+H6tk7LzQ7kPqbAgLjdzNE32+u3Ff11gXt9Kkkd2nusGFrlWMIe+XaA97t+I8JS7sZIrvRgA==",
       "hasInstallScript": true,
       "dependencies": {
         "@derhuerst/http-basic": "^8.2.0",
@@ -569,34 +587,15 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/form-data": {
@@ -759,16 +758,16 @@
       "dev": true
     },
     "node_modules/libsodium": {
-      "version": "0.7.11",
-      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.11.tgz",
-      "integrity": "sha512-WPfJ7sS53I2s4iM58QxY3Inb83/6mjlYgcmZs7DJsvDlnmVUwNinBCi5vBT43P6bHRy01O4zsMU2CoVR6xJ40A=="
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.15.tgz",
+      "integrity": "sha512-sZwRknt/tUpE2AwzHq3jEyUU5uvIZHtSssktXq7owd++3CSgn8RGrv6UZJJBpP7+iBghBqe7Z06/2M31rI2NKw=="
     },
     "node_modules/libsodium-wrappers": {
-      "version": "0.7.11",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.11.tgz",
-      "integrity": "sha512-SrcLtXj7BM19vUKtQuyQKiQCRJPgbpauzl3s0rSwD+60wtHqSUuqcoawlMDheCJga85nKOQwxNYQxf/CKAvs6Q==",
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.15.tgz",
+      "integrity": "sha512-E4anqJQwcfiC6+Yrl01C1m8p99wEhLmJSs0VQqST66SbQXXBoaJY0pF4BNjRYa/sOQAxx6lXAaAFIlx+15tXJQ==",
       "dependencies": {
-        "libsodium": "^0.7.11"
+        "libsodium": "^0.7.15"
       }
     },
     "node_modules/lodash": {
@@ -793,9 +792,9 @@
       }
     },
     "node_modules/magic-bytes.js": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.0.15.tgz",
-      "integrity": "sha512-bpRmwbRHqongRhA+mXzbLWjVy7ylqmfMBYaQkSs6pac0z6hBTvsgrH0r4FBYd/UYVJBmS6Rp/O+oCCQVLzKV1g=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
+      "integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ=="
     },
     "node_modules/map-stream": {
       "version": "0.1.0",
@@ -821,12 +820,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -931,9 +930,9 @@
       "integrity": "sha512-ZAqHUKkQLix2Iga7pPbsf1LpUoBjcpwU93F1l3qBIfxYddQLhxS6GKmS0d3jV8kSVaUbr6NnOEcEMFvuX93SWQ=="
     },
     "node_modules/play-dl": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/play-dl/-/play-dl-1.9.6.tgz",
-      "integrity": "sha512-JW44bQbME9fNfGhGXQ/rdcsHr4BfgJabVlSgpS9QY/NscfprFH1asv+q9atrZThP3+hHIpgtFNABccg9rFWlwg==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/play-dl/-/play-dl-1.9.7.tgz",
+      "integrity": "sha512-KpgerWxUCY4s9Mhze2qdqPhiqd8Ve6HufpH9mBH3FN+vux55qSh6WJKDabfie8IBHN7lnrAlYcT/UdGax58c2A==",
       "dependencies": {
         "play-audio": "^0.5.2"
       },
@@ -942,11 +941,11 @@
       }
     },
     "node_modules/prism-media": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.4.tgz",
-      "integrity": "sha512-eW7LXORkTCQznZs+eqe9VjGOrLBxcBPXgNyHXMTSRVhphvd/RrxgIR7WaWt4fkLuhshcdT5KHL88LAfcvS3f5g==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
+      "integrity": "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==",
       "peerDependencies": {
-        "@discordjs/opus": "^0.8.0",
+        "@discordjs/opus": ">=0.8.0 <1.0.0",
         "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
         "node-opus": "^0.3.3",
         "opusscript": "^0.0.8"
@@ -973,11 +972,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/ps-tree": {
       "version": "1.2.0",
@@ -1042,14 +1036,14 @@
       }
     },
     "node_modules/resolve-tspaths": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/resolve-tspaths/-/resolve-tspaths-0.8.15.tgz",
-      "integrity": "sha512-uqxasvZ7WGMfaozpwSLo5nEV/TBnbwMSV7df7hLfwtmGNQlqO1ljcTJ5s8EX9MidKlMQLnczCwur9gFtbOc6pA==",
+      "version": "0.8.19",
+      "resolved": "https://registry.npmjs.org/resolve-tspaths/-/resolve-tspaths-0.8.19.tgz",
+      "integrity": "sha512-yZkXNYyHdVytOkJLhbib7TFpaMVElk9auO9R1jDmOSXPUWEjy+V44VqX77RIQ+kf0UJIlAGRDK/yrbfwlu1UWg==",
       "dev": true,
       "dependencies": {
         "ansi-colors": "4.1.3",
-        "commander": "11.0.0",
-        "fast-glob": "3.3.1"
+        "commander": "12.0.0",
+        "fast-glob": "3.3.2"
       },
       "bin": {
         "resolve-tspaths": "dist/main.js"
@@ -1179,14 +1173,6 @@
         "duplexer": "~0.1.1"
       }
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -1223,14 +1209,14 @@
       }
     },
     "node_modules/ts-mixer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
-      "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
     },
     "node_modules/tsc-watch": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/tsc-watch/-/tsc-watch-6.0.4.tgz",
-      "integrity": "sha512-cHvbvhjO86w2aGlaHgSCeQRl+Aqw6X6XN4sQMPZKF88GoP30O+oTuh5lRIJr5pgFWrRpF1AgXnJJ2DoFEIPHyg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tsc-watch/-/tsc-watch-6.2.0.tgz",
+      "integrity": "sha512-2LBhf9kjKXnz7KQ/puLHlozMzzUNHAdYBNMkg3eksQJ9GBAgMg8czznM83T5PmsoUvDnXzfIeQn2lNcIYDr8LA==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -1259,9 +1245,9 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -1272,14 +1258,11 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
-      "dependencies": {
-        "busboy": "^1.6.0"
-      },
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.13.0.tgz",
+      "integrity": "sha512-Q2rtqmZWrbP8nePMq7mOJIN98M0fYvSgV89vwl/BQRT4mDOeY2GXZngfGpcBBhtky3woM7G24wZV3Q304Bv6cw==",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -1308,9 +1291,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@discordjs/voice": "^0.17.0",
-        "@hizollo/calculator": "^1.0.2",
+        "@hizollo/calculator": "^1.1.1",
         "@hizollo/games": "^2.5.0",
         "@hizollo/osu-api": "^1.2.0",
         "discord.js": "^14.15.3",
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/@hizollo/calculator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@hizollo/calculator/-/calculator-1.0.2.tgz",
-      "integrity": "sha512-NKi+Hp75RMr57fH8CPJRymUSSXNfwWc8uJk9j/Fyn1PDd7GwDneAjYre0ey/qdTPUuPHx0zn7UmqagdXbwf6+A=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@hizollo/calculator/-/calculator-1.1.1.tgz",
+      "integrity": "sha512-cZrAvk3ZdNoRtGbppxj7uKlsUss8aYCdRq2hA5LjioZDmT4IP+Or8OmzozbFdfB+cIa4MgH36gQccQ5hDht9hg=="
     },
     "node_modules/@hizollo/games": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/src/index.js",
   "private": true,
   "engines": {
-    "node": "^18.2.1"
+    "node": ">=18.2.1"
   },
   "scripts": {
     "dev": "tsc-watch --onSuccess resolve-tspaths",
@@ -30,21 +30,20 @@
   },
   "homepage": "https://github.com/HiZollo/Junior-HiZollo#readme",
   "dependencies": {
-    "@discordjs/voice": "^0.13.0",
-    "@hizollo/calculator": "^1.0.2",
+    "@discordjs/voice": "^0.17.0",
+    "@hizollo/calculator": "^1.1.1",
     "@hizollo/games": "^2.5.0",
     "@hizollo/osu-api": "^1.2.0",
-    "axios": "^1.4.0",
-    "discord.js": "^14.13.0",
-    "dotenv": "^16.3.1",
-    "emoji-regex": "^10.2.1",
-    "ffmpeg-static": "^5.1.0",
-    "libsodium-wrappers": "^0.7.11",
-    "play-dl": "^1.9.6"
+    "discord.js": "^14.15.3",
+    "dotenv": "^16.4.5",
+    "emoji-regex": "^10.3.0",
+    "ffmpeg-static": "^5.2.0",
+    "libsodium-wrappers": "^0.7.15",
+    "play-dl": "^1.9.7"
   },
   "devDependencies": {
-    "resolve-tspaths": "^0.8.15",
-    "tsc-watch": "^6.0.4",
-    "typescript": "^5.2.2"
+    "resolve-tspaths": "^0.8.19",
+    "tsc-watch": "^6.2.0",
+    "typescript": "^5.4.5"
   }
 }

--- a/src/classes/CommandParser.ts
+++ b/src/classes/CommandParser.ts
@@ -19,11 +19,11 @@
  */
 
 import { ApplicationCommandOptionChoiceData, ApplicationCommandOptionType, Attachment, ChatInputCommandInteraction, Message, MessageMentions } from "discord.js";
-import emojiRegex from "emoji-regex";
 import { ArgumentParseType, CommandOptionType, CommandParserOptionResultStatus } from "../typings/enums";
 import { CommandParserOptionResult, CommandParserResult } from "../typings/types";
 import { ArgumentParseMethod, HZCommandOptionData } from "../typings/types";
 import { Command } from "./Command";
+import isEmoji from "../features/utils/isEmoji";
 
 type ParseMessageOptionFunctions = {
   [key in ApplicationCommandOptionType]: (data: {
@@ -299,7 +299,7 @@ export class CommandParser extends null {
           return { arg: original, status: CommandParserOptionResultStatus.NotInChoices, choices: data.choices };
         }
       }
-      if (data.parseAs === CommandOptionType.Emoji && !emojiRegex().test(argument) && !/<?(a)?:?(\w{2,32}):(\d{17,20})>?/.test(argument)) {
+      if (data.parseAs === CommandOptionType.Emoji && !isEmoji(argument)) {
         return { arg: original, status: CommandParserOptionResultStatus.WrongFormat };
       }
       if ('minLength' in data) {
@@ -390,7 +390,7 @@ export class CommandParser extends null {
       if (argument === null) {
         return { arg: null, status: CommandParserOptionResultStatus.Pass };
       }
-      if (data.parseAs === CommandOptionType.Emoji && !emojiRegex().test(argument) && !/<?(a)?:?(\w{2,32}):(\d{17,19})>?/.test(argument) && !/[🇦-🇿]/u.test(argument)) {
+      if (data.parseAs === CommandOptionType.Emoji && !isEmoji(argument)) {
         return { arg: null, status: CommandParserOptionResultStatus.WrongFormat };
       }
       return { arg: argument, status: CommandParserOptionResultStatus.Pass };

--- a/src/commands/Calc.ts
+++ b/src/commands/Calc.ts
@@ -22,7 +22,7 @@ import { CalcError, Calculator, ErrorCodes } from "@hizollo/calculator";
 import { ApplicationCommandOptionType } from "discord.js";
 import { Command } from "../classes/Command";
 import { Source } from "../classes/Source";
-import removeMd from "../features/utils/removeMd";
+// import removeMd from "../features/utils/removeMd";
 import { ArgumentParseType, CommandType } from "../typings/enums";
 
 export default class Calc extends Command<[string]> {
@@ -55,7 +55,7 @@ export default class Calc extends Command<[string]> {
         return;
       }
       await source.defer();
-      await source.update(`算式：\n> ${removeMd(formula)}\n\n結果：\n> ${removeMd(result)}`);
+      await source.update(`算式：\n\`\`\`\n${formula}\n\`\`\`\n結果：\n\`\`\`\n${result}\n\`\`\``);
     } catch (error: unknown) {
       const err = error as CalcError<ErrorCodes>
       await source.defer({ ephemeral: true });
@@ -84,6 +84,7 @@ export default class Calc extends Command<[string]> {
 
     // Implementation
     [ErrorCodes.EmptyStack]: `指令好像出了一點問題，請你將你的算式和以下錯誤訊息使用 \`bug\` 指令回報給開發者：\n\`\`\`\nError: The expression stack is empty.\n\`\`\``, 
-    [ErrorCodes.NonEmptyStack]: `指令好像出了一點問題，請你將你的算式和以下錯誤訊息使用 \`bug\` 指令回報給開發者：\n\`\`\`Error: Non-empty stack after parsing.\n\`\`\``, 
+    [ErrorCodes.NonEmptyStack]: `指令好像出了一點問題，請你將你的算式和以下錯誤訊息使用 \`bug\` 指令回報給開發者：\n\`\`\`Error: Non-empty stack after parsing.\n\`\`\``,
+    [ErrorCodes.StackOverflow]: `你的運算式太長了，請你考慮分段計算，不然我的腦袋要爆了。`, 
   } as const;
 }

--- a/src/features/utils/isEmoji.ts
+++ b/src/features/utils/isEmoji.ts
@@ -1,0 +1,37 @@
+/*
+ * 
+ * Copyright 2022 HiZollo Dev Team <https://github.com/hizollo>
+ * 
+ * This file is a part of Junior HiZollo.
+ * 
+ * Junior HiZollo is free software: you can redistribute it and/or 
+ * modify it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Junior HiZollo is distributed in the hope that it will be useful, 
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Junior HiZollo. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import emojiRegex from "emoji-regex";
+const regex = emojiRegex();
+/**
+ * 檢查一個一串是不是表情符號，或是否符合 Discord 的表情符號格式
+ */
+export default function isEmoji(target: string): boolean {
+  // 是否為表情符號
+  if (regex.test(target)) return true;
+
+  // 是否為 Discord 的自訂表情符號
+  if (/<?(a)?:?(\w{2,32}):(\d{17,19})>?/.test(target)) return true;
+
+  // 是否為區域指示碼
+  if (/[\ud83c[\udde6-\uddff]/.test(target)) return true;
+
+  return false;
+}

--- a/src/features/utils/modalSystem.ts
+++ b/src/features/utils/modalSystem.ts
@@ -29,6 +29,8 @@ type CustomMessageOptions = Omit<MessageCreateOptions, 'flags'> & { fetchReply?:
  * @returns 使用者提交的表單互動
  */
 export default async function modelSystem({ source, buttons: { open, close }, modal, time = 60e3, contents }: ModelSystemOptions): Promise<ModalSubmitInteraction | null> {
+  if (!source.client.isReady()) return null;
+
   if (buttonIsLink(open.data) || buttonIsLink(close.data)) {
     throw new Error('Some of the buttons are link buttons.');
   }

--- a/src/features/utils/modalSystem.ts
+++ b/src/features/utils/modalSystem.ts
@@ -19,7 +19,7 @@
  */
 
 import { InteractionCollector, ActionRowBuilder, MessageCreateOptions, ComponentType, InteractionType, ButtonBuilder, APIButtonComponent, ButtonStyle, APIButtonComponentWithURL, ModalSubmitInteraction, Collection } from 'discord.js';
-import { ModelSystemContentOptions, ModelSystemOptions } from '../../typings/interfaces';
+import { ModalSystemContentOptions, ModalSystemOptions } from '../../typings/interfaces';
 
 type CustomMessageOptions = Omit<MessageCreateOptions, 'flags'> & { fetchReply?: boolean };
 
@@ -28,7 +28,7 @@ type CustomMessageOptions = Omit<MessageCreateOptions, 'flags'> & { fetchReply?:
  * @param options 選項
  * @returns 使用者提交的表單互動
  */
-export default async function modelSystem({ source, buttons: { open, close }, modal, time = 60e3, contents }: ModelSystemOptions): Promise<ModalSubmitInteraction | null> {
+export default async function modalSystem({ source, buttons: { open, close }, modal, time = 60e3, contents }: ModalSystemOptions): Promise<ModalSubmitInteraction | null> {
   if (!source.client.isReady()) return null;
 
   if (buttonIsLink(open.data) || buttonIsLink(close.data)) {
@@ -38,7 +38,7 @@ export default async function modelSystem({ source, buttons: { open, close }, mo
     throw new Error('Some of the buttons don\'t have custom ids set.');
   }
   if (!modal.data.custom_id) {
-    throw new Error('The model doesn\'t have custom id set.');
+    throw new Error('The modal doesn\'t have custom id set.');
   }
 
   const openCustomId = open.data.custom_id;
@@ -109,19 +109,19 @@ export default async function modelSystem({ source, buttons: { open, close }, mo
 }
 
 /**
- * 把給定物件`{ [key: keyof ModelSystemContentOptions]: string }` 對應出一個新物件，使新物件的鍵與原物件相同，但值是 `{ content: string }`
+ * 把給定物件`{ [key: keyof ModalSystemContentOptions]: string }` 對應出一個新物件，使新物件的鍵與原物件相同，但值是 `{ content: string }`
  * @param contents 給定物件
  * @returns 新物件
  */
-function getMessageOptions(contents: ModelSystemContentOptions): Record<keyof ModelSystemContentOptions, CustomMessageOptions> {
+function getMessageOptions(contents: ModalSystemContentOptions): Record<keyof ModalSystemContentOptions, CustomMessageOptions> {
   // 暫時設成 Partial，實際上所有鍵都會有值對應
-  let messageOptions: Partial<Record<keyof ModelSystemContentOptions, CustomMessageOptions>> = {};
+  let messageOptions: Partial<Record<keyof ModalSystemContentOptions, CustomMessageOptions>> = {};
 
   for (const key in contents) {
-    messageOptions[key as keyof ModelSystemContentOptions] = { content: contents[key as keyof ModelSystemContentOptions] };
+    messageOptions[key as keyof ModalSystemContentOptions] = { content: contents[key as keyof ModalSystemContentOptions] };
   }
   
-  return messageOptions as Record<keyof ModelSystemContentOptions, CustomMessageOptions>;
+  return messageOptions as Record<keyof ModalSystemContentOptions, CustomMessageOptions>;
 }
 
 /**

--- a/src/typings/interfaces.ts
+++ b/src/typings/interfaces.ts
@@ -113,21 +113,21 @@ export interface CooldownManagerAddUserOptions extends CooldownManagerMethodOpti
   duration?: number;
 }
 
-export interface ModelSystemContentOptions {
+export interface ModalSystemContentOptions {
   start: string;
   success: string;
   exit: string;
   idle: string;
 }
 
-export interface ModelSystemOptions {
+export interface ModalSystemOptions {
   source: Source;
   buttons: {
     open: ButtonBuilder,
     close: ButtonBuilder
   };
   modal: ModalBuilder;
-  contents: ModelSystemContentOptions;
+  contents: ModalSystemContentOptions;
   time?: number;
 }
 


### PR DESCRIPTION
- 被更新套件
  - `@discordjs/voice`：0.13.0 -> 0.17.0
  - `@hizollo/calculator`：1.0.2 -> 1.1.1
  - `discord.js`：14.13.0 -> 14.15.3
  - `dotenv`：16.3.1 -> 16.4.5
  - `emoji-regex`：10.2.1 -> 10.3.0
  - `ffmpeg-static`：5.1.0 -> 5.2.0
  - `libsodium-wrappers`：0.7.11 -> 0.7.15
  - `play-dl`：1.9.6 -> 1.9.7
  - `resolve-tspaths`：0.8.15 -> 0.8.19
  - `tsc-watch`：6.0.4 -> 6.2.0
  - `typescript`：5.2.2 -> 5.4.5
    - 因為最新的 5.5.4 版的 `EventEmitter` 的型別有問題，所以沒有升到最新版
 - 被刪除套件：`axios`
 - 將 node 所需的版本更改為 `>=18.2.1`
 - 修復漏洞
   - Typescript 的抱怨
   - 將 `isEmoji()` 獨立成一個 util，並使用 Unicode 來檢查區域指示碼
   - 補齊 `calc` 指令缺少的錯誤訊息
   - 更改 `calc` 指令的輸出形式以避免結果超出 Discord 的 2000 字元上限